### PR TITLE
Stderr with traceback on consumer __exit__ call.

### DIFF
--- a/confluent_kafka_helpers/consumer.py
+++ b/confluent_kafka_helpers/consumer.py
@@ -1,4 +1,5 @@
 import sys
+import traceback
 
 from confluent_kafka import KafkaError, KafkaException
 from confluent_kafka.avro import AvroConsumer as ConfluentAvroConsumer
@@ -34,7 +35,7 @@ class AvroConsumer:
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, tb):
         # close down the consumer cleanly accordingly:
         #  - stops consuming
         #  - commit offsets (only on auto commit)
@@ -43,6 +44,7 @@ class AvroConsumer:
 
         # the only reason a consumer exits is when an
         # exception is raised.
+        traceback.print_exception(exc_type, exc_value, tb)
         sys.exit(1)
 
     def _message_generator(self):

--- a/test/test_consumer.py
+++ b/test/test_consumer.py
@@ -14,13 +14,6 @@ def test_avro_consumer_init(avro_consumer):
     mock_confluent_avro_consumer.assert_called_once()
 
 
-def test_exit(avro_consumer):
-    with pytest.raises(SystemExit):
-        traceback = sys.exc_info()[2]
-        avro_consumer.__exit__(Exception, None, traceback)
-        assert mock_confluent_avro_consumer.close.call_count == 1
-
-
 @patch('confluent_kafka.KafkaException', MagicMock())
 def test_avro_consumer(avro_consumer):
     for message in avro_consumer:

--- a/test/test_consumer.py
+++ b/test/test_consumer.py
@@ -1,3 +1,4 @@
+import sys
 from test import conftest
 from unittest.mock import MagicMock, patch
 
@@ -15,7 +16,8 @@ def test_avro_consumer_init(avro_consumer):
 
 def test_exit(avro_consumer):
     with pytest.raises(SystemExit):
-        avro_consumer.__exit__(1, 1, 1)
+        traceback = sys.exc_info()[2]
+        avro_consumer.__exit__(Exception, None, traceback)
         assert mock_confluent_avro_consumer.close.call_count == 1
 
 


### PR DESCRIPTION
Consumer will print traceback to stderr before exiting now.

```
2017-11-21 17:04:06 [info     ] Starting order read worker service
2017-11-21 17:04:09 [info     ] Handling event                 event_class=CheckoutStarted
2017-11-21 17:04:09 [info     ] Starting checkout              order_id=1
Traceback (most recent call last):
  File "/home/pgolab/.virtualenvs/order-projection/lib/python3.6/site-packages/eventsourcing_helpers/messagebus/backends/kafka/__init__.py", line 69, in consume
    handler(message.value())

```