### PR TITLE
Yield new message class in consumer and force api.version.request config value

### DIFF
--- a/confluent_kafka_helpers/consumer.py
+++ b/confluent_kafka_helpers/consumer.py
@@ -1,6 +1,7 @@
 
 from confluent_kafka import KafkaError, KafkaException
 from confluent_kafka.avro import AvroConsumer as ConfluentAvroConsumer
+from confluent_kafka_helpers.message import Message
 
 
 class AvroConsumer:
@@ -10,7 +11,8 @@ class AvroConsumer:
         'enable.auto.commit': False,
         'default.topic.config': {
             'auto.offset.reset': 'earliest'
-        }
+        },
+        'api.version.request': True
     }
 
     def __init__(self, config):

--- a/confluent_kafka_helpers/consumer.py
+++ b/confluent_kafka_helpers/consumer.py
@@ -54,7 +54,7 @@ class AvroConsumer:
             if message.error().code() != KafkaError._PARTITION_EOF:
                 raise KafkaException(message.error())
 
-        yield message
+        yield Message(message)
 
     def _get_topics(self, config):
         topics = config.pop('topics', None)

--- a/confluent_kafka_helpers/loader.py
+++ b/confluent_kafka_helpers/loader.py
@@ -29,7 +29,8 @@ class AvroMessageLoader:
     DEFAULT_CONSUMER_CONFIG = {
         'default.topic.config': {
             'auto.offset.reset': 'earliest'
-        }
+        },
+        'api.version.request': True
     }
 
     def __init__(self, config):

--- a/confluent_kafka_helpers/loader.py
+++ b/confluent_kafka_helpers/loader.py
@@ -5,6 +5,7 @@ from confluent_kafka import KafkaError, KafkaException, TopicPartition
 from confluent_kafka.avro import AvroConsumer
 from confluent_kafka_helpers import logger
 from confluent_kafka_helpers.schema_registry import AvroSchemaRegistry
+from confluent_kafka_helpers.message import Message
 
 
 def default_partitioner(key, num_partitions):
@@ -104,8 +105,10 @@ class AvroMessageLoader:
                     else:
                         raise KafkaException(message.error())
 
+                message = Message(message)
+
                 message_key, message_value, message_offset = (
-                    message.key(), message.value(), message.offset()
+                    message._meta.key, message.value, message._meta.offset
                 )
                 if key_filter(key, message_key):
                     logger.debug(

--- a/confluent_kafka_helpers/loader.py
+++ b/confluent_kafka_helpers/loader.py
@@ -4,8 +4,8 @@ from functools import partial
 from confluent_kafka import KafkaError, KafkaException, TopicPartition
 from confluent_kafka.avro import AvroConsumer
 from confluent_kafka_helpers import logger
-from confluent_kafka_helpers.schema_registry import AvroSchemaRegistry
 from confluent_kafka_helpers.message import Message
+from confluent_kafka_helpers.schema_registry import AvroSchemaRegistry
 
 
 def default_partitioner(key, num_partitions):

--- a/confluent_kafka_helpers/message.py
+++ b/confluent_kafka_helpers/message.py
@@ -8,7 +8,7 @@ import datetime
 
 class Message:
     __slots__ = [
-        "value", "error", "_raw", "_meta"
+        "value", "_raw", "_meta"
     ]
 
     def __init__(self, kafka_message):

--- a/confluent_kafka_helpers/message.py
+++ b/confluent_kafka_helpers/message.py
@@ -8,7 +8,7 @@ import datetime
 
 class Message:
     __slots__ = [
-        "value", "_raw", "_meta"
+        "value", "error", "_raw", "_meta"
     ]
 
     def __init__(self, kafka_message):
@@ -30,7 +30,7 @@ class MessageMetadata:
         self.topic = kafka_message.topic()
 
         timestamp_type, timestamp = kafka_message.timestamp()
-        if timestamp_type == 0 or timestamp == -1:
+        if timestamp_type == 0 or timestamp <= 0:
             timestamp = None
         self.timestamp = timestamp
 

--- a/confluent_kafka_helpers/message.py
+++ b/confluent_kafka_helpers/message.py
@@ -17,6 +17,19 @@ class Message:
         self._meta = MessageMetadata(kafka_message)
 
 
+def kafka_timestamp_to_datetime(timestamp):
+    return datetime.datetime.utcfromtimestamp(
+        timestamp / 1000.0
+    ) if timestamp is not None else None
+
+
+def extract_timestamp_from_message(kafka_message):
+        timestamp_type, timestamp = kafka_message.timestamp()
+        if timestamp_type == 0 or timestamp <= 0:
+            timestamp = None
+        return timestamp
+
+
 class MessageMetadata:
     __slots__ = [
         "key", "partition", "offset", "timestamp",
@@ -28,12 +41,5 @@ class MessageMetadata:
         self.partition = kafka_message.partition()
         self.offset = kafka_message.offset()
         self.topic = kafka_message.topic()
-
-        timestamp_type, timestamp = kafka_message.timestamp()
-        if timestamp_type == 0 or timestamp <= 0:
-            timestamp = None
-        self.timestamp = timestamp
-
-        self.datetime = datetime.datetime.utcfromtimestamp(
-            timestamp / 1000.0
-        ) if self.timestamp is not None else None
+        self.timestamp = extract_timestamp_from_message(kafka_message)
+        self.datetime = kafka_timestamp_to_datetime(self.timestamp)

--- a/confluent_kafka_helpers/message.py
+++ b/confluent_kafka_helpers/message.py
@@ -24,10 +24,10 @@ def kafka_timestamp_to_datetime(timestamp):
 
 
 def extract_timestamp_from_message(kafka_message):
-        timestamp_type, timestamp = kafka_message.timestamp()
-        if timestamp_type == 0 or timestamp <= 0:
-            timestamp = None
-        return timestamp
+    timestamp_type, timestamp = kafka_message.timestamp()
+    if timestamp_type == 0 or timestamp <= 0:
+        timestamp = None
+    return timestamp
 
 
 class MessageMetadata:

--- a/confluent_kafka_helpers/message.py
+++ b/confluent_kafka_helpers/message.py
@@ -1,0 +1,39 @@
+"""
+This module only contains the Message class
+definition for yielding in the consumers of
+kafka messages.
+"""
+import datetime
+
+
+class Message:
+    __slots__ = [
+        "value", "_raw", "_meta"
+    ]
+
+    def __init__(self, kafka_message):
+        self.value = kafka_message.value()
+        self._raw = kafka_message
+        self._meta = MessageMetadata(kafka_message)
+
+
+class MessageMetadata:
+    __slots__ = [
+        "key", "partition", "offset", "timestamp",
+        "datetime", "topic"
+    ]
+
+    def __init__(self, kafka_message):
+        self.key = kafka_message.key()
+        self.partition = kafka_message.partition()
+        self.offset = kafka_message.offset()
+        self.topic = kafka_message.topic()
+
+        timestamp_type, timestamp = kafka_message.timestamp()
+        if timestamp_type == 0 or timestamp == -1:
+            timestamp = None
+        self.timestamp = timestamp
+
+        self.datetime = datetime.datetime.utcfromtimestamp(
+            timestamp / 1000.0
+        ) if self.timestamp is not None else None

--- a/confluent_kafka_helpers/producer.py
+++ b/confluent_kafka_helpers/producer.py
@@ -17,7 +17,7 @@ class AvroProducer(ConfluentAvroProducer):
 
     DEFAULT_CONFIG = {
         'log.connection.close': False,
-        'api.version.request': True
+        'api.version.request': True,
         'queue.buffering.max.ms': 0,
         'socket.blocking.max.ms': 1
     }

--- a/confluent_kafka_helpers/producer.py
+++ b/confluent_kafka_helpers/producer.py
@@ -15,7 +15,10 @@ class TopicNotRegistered(Exception):
 
 class AvroProducer(ConfluentAvroProducer):
 
-    DEFAULT_CONFIG = {'log.connection.close': False}
+    DEFAULT_CONFIG = {
+        'log.connection.close': False,
+        'api.version.request': True
+    }
 
     def __init__(self, config, value_serializer=None,
                  schema_registry=AvroSchemaRegistry):  # yapf: disable

--- a/confluent_kafka_helpers/producer.py
+++ b/confluent_kafka_helpers/producer.py
@@ -1,8 +1,7 @@
 from confluent_kafka.avro import AvroProducer as ConfluentAvroProducer
-
 from confluent_kafka_helpers import logger
-from confluent_kafka_helpers.schema_registry import (
-    AvroSchemaRegistry, SchemaNotFound)
+from confluent_kafka_helpers.schema_registry import (AvroSchemaRegistry,
+                                                     SchemaNotFound)
 
 
 class TopicNotRegistered(Exception):

--- a/confluent_kafka_helpers/schema_registry.py
+++ b/confluent_kafka_helpers/schema_registry.py
@@ -1,8 +1,8 @@
 from confluent_kafka import avro
-from confluent_kafka.avro.cached_schema_registry_client import (
-    CachedSchemaRegistryClient)
-from confluent_kafka.avro.serializer.message_serializer import MessageSerializer
-
+from confluent_kafka.avro.cached_schema_registry_client import \
+    CachedSchemaRegistryClient
+from confluent_kafka.avro.serializer.message_serializer import \
+    MessageSerializer
 from confluent_kafka_helpers import logger
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(name="confluent_kafka_helpers",
       version="0.1",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,11 +1,9 @@
+from test import config
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from confluent_kafka.avro import AvroConsumer as ConfluentAvroConsumer
 from confluent_kafka_helpers import consumer
-
-from test import config
 
 number_of_messages = 1
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -19,6 +19,12 @@ class PollReturnMock:
     key.return_value = 1
     offset = MagicMock()
     offset.side_effect = [i for i in range(0, number_of_messages)]
+    partition = MagicMock()
+    partition.return_value = 1
+    topic = MagicMock()
+    topic.return_value = "test"
+    timestamp = MagicMock()
+    timestamp.return_value = (1, -1)
 
 
 class ConfluentAvroConsumerMock(MagicMock):

--- a/test/test_consumer.py
+++ b/test/test_consumer.py
@@ -17,5 +17,5 @@ def test_avro_consumer_init(avro_consumer):
 @patch('confluent_kafka.KafkaException', MagicMock())
 def test_avro_consumer(avro_consumer):
     for message in avro_consumer:
-        assert message.value() == b'foobar'
+        assert message.value == b'foobar'
         break

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -1,10 +1,8 @@
+from test import config, conftest
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from confluent_kafka_helpers import loader
-from test import config
-from test import conftest
 
 mock_avro_consumer = conftest.ConfluentAvroConsumerMock(
     name='ConfluentAvroConsumerMock'

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -1,0 +1,82 @@
+"""
+Test messages are properly turned into a Message object
+"""
+from unittest.mock import Mock
+import datetime
+
+from confluent_kafka_helpers.message import Message
+
+
+mock_message = Mock()
+mock_message.value = Mock(return_value={"data": "test"})
+mock_message.key = Mock(return_value="test")
+mock_message.partition = Mock(return_value=2)
+mock_message.offset = Mock(return_value=100)
+mock_message.topic = Mock(return_value="testing_topic")
+
+
+def test_message_object():
+    """
+    tests to ensure that when handed an object with all of the
+    kafka message methods, the new Message object has the correct
+    attributes set.
+    """
+
+    # valid timestamp
+    mock_message.timestamp = Mock(
+        return_value=(
+            1, (datetime.datetime(2017, 1, 15) - datetime.datetime(1970, 1, 1)).total_seconds()*1000.0
+        )
+    )
+
+    new_message = Message(mock_message)
+
+    assert new_message.value == mock_message.value()
+    assert new_message._raw == mock_message
+    assert new_message._meta.key == mock_message.key()
+    assert new_message._meta.partition == mock_message.partition()
+    assert new_message._meta.offset == mock_message.offset()
+    assert new_message._meta.topic == mock_message.topic()
+    assert new_message._meta.timestamp == mock_message.timestamp()[1]
+
+    assert new_message._meta.datetime == datetime.datetime(2017, 1, 15)
+
+
+def test_timestamp_is_negative():
+    """
+    If the timestamp is negative (not set by kafka),
+    it should be reflected as None in the message metadata
+    """
+    mock_message.timestamp = Mock(
+        return_value=(1, -1)
+    )
+    new_message = Message(mock_message)
+
+    assert new_message.value == mock_message.value()
+    assert new_message._raw == mock_message
+    assert new_message._meta.key == mock_message.key()
+    assert new_message._meta.partition == mock_message.partition()
+    assert new_message._meta.offset == mock_message.offset()
+    assert new_message._meta.topic == mock_message.topic()
+    assert new_message._meta.timestamp is None
+    assert new_message._meta.datetime is None
+
+
+def test_timestamp_is_not_available():
+    """
+    If the timestamp is 0 and not available,
+    it should be reflected as None in the message metadata
+    """
+    mock_message.timestamp = Mock(
+        return_value=(0, 0)
+    )
+    new_message = Message(mock_message)
+
+    assert new_message.value == mock_message.value()
+    assert new_message._raw == mock_message
+    assert new_message._meta.key == mock_message.key()
+    assert new_message._meta.partition == mock_message.partition()
+    assert new_message._meta.offset == mock_message.offset()
+    assert new_message._meta.topic == mock_message.topic()
+    assert new_message._meta.timestamp is None
+    assert new_message._meta.datetime is None

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -1,13 +1,12 @@
 """
 Test messages are properly turned into a Message object
 """
-from unittest.mock import Mock
 import datetime
+from unittest.mock import Mock
 
-from confluent_kafka_helpers.message import (
-    Message, extract_timestamp_from_message, kafka_timestamp_to_datetime
-)
-
+from confluent_kafka_helpers.message import (Message,
+                                             extract_timestamp_from_message,
+                                             kafka_timestamp_to_datetime)
 
 mock_message = Mock()
 mock_message.value = Mock(return_value={"data": "test"})

--- a/test/test_schema_registry.py
+++ b/test/test_schema_registry.py
@@ -1,9 +1,8 @@
+from test import config
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from confluent_kafka_helpers import schema_registry
-from test import config
 
 
 class CachedSchemaRegistryClientMock(MagicMock):


### PR DESCRIPTION
Changes as per discussion this afternoon regarding getting the timestamps for Kafka events generated. Now all messages yielded or loaded will be of confluent_kafka_helpers.Message type.