### PR TITLE
Created a AvroRawConsumer and decoding the messages after filtering

### DIFF
--- a/confluent_kafka_helpers/loader.py
+++ b/confluent_kafka_helpers/loader.py
@@ -8,7 +8,7 @@ from functools import partial
 import structlog
 from confluent_kafka import KafkaError, KafkaException, TopicPartition
 
-from confluent_kafka_helpers.consumer import AvroRawConsumer
+from confluent_kafka_helpers.consumer import AvroLazyConsumer
 from confluent_kafka_helpers.message import Message
 from confluent_kafka_helpers.metrics import base_metric, statsd
 from confluent_kafka_helpers.schema_registry import AvroSchemaRegistry
@@ -149,7 +149,7 @@ class AvroMessageLoader:
 
         consumer_config = {**self.DEFAULT_CONFIG, **config['consumer']}
         logger.info("Initializing loader", config=consumer_config)
-        self.consumer = AvroRawConsumer(consumer_config)
+        self.consumer = AvroLazyConsumer(consumer_config)
 
         atexit.register(self._close)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -18,7 +18,7 @@ mock_partitioner.return_value = 1
 
 
 @pytest.fixture(scope='function')
-@patch('confluent_kafka_helpers.loader.AvroRawConsumer', mock_avro_consumer)
+@patch('confluent_kafka_helpers.loader.AvroLazyConsumer', mock_avro_consumer)
 @patch(
     'confluent_kafka_helpers.loader.AvroSchemaRegistry',
     mock_avro_schema_registry()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -18,7 +18,7 @@ mock_partitioner.return_value = 1
 
 
 @pytest.fixture(scope='function')
-@patch('confluent_kafka_helpers.loader.AvroConsumer', mock_avro_consumer)
+@patch('confluent_kafka_helpers.loader.AvroRawConsumer', mock_avro_consumer)
 @patch(
     'confluent_kafka_helpers.loader.AvroSchemaRegistry',
     mock_avro_schema_registry()
@@ -62,6 +62,8 @@ def test_avro_message_loader_load(avro_message_loader):
     conftest.mock_confluent_avro_consumer.poll.side_effect = [
         message, StopIteration
     ]
+    avro_message_loader.key_serializer = lambda arg: arg
+
     messages = list(
         avro_message_loader.load(key=1, partitioner=mock_partitioner)
     )


### PR DESCRIPTION
Created the `AvroRawConsumer` this is a wrapper around the `ConfluentAvroConsumer` without decoding the messages in the `poll`.

Changed the `AvroMessageLoader` to use the `serialized_key` in the `MessageGenerator` and changed the `MessageGenerator` to decode our messages after the filtering process.

This will decrease the number of `decoding` we do significantly.

Before
=====
```python
184091 function calls (184047 primitive calls) in 0.333 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    11080    0.165    0.000    0.165    0.000 {built-in method fastavro._reader.read_data}
    11080    0.047    0.000    0.246    0.000 message_serializer.py:198(decode_message)
     5541    0.031    0.000    0.308    0.000 __init__.py:98(poll)
     5541    0.022    0.000    0.022    0.000 {function AvroConsumer.poll at 0x7f23d0a1b6a8}
       17    0.015    0.001    0.328    0.019 loader.py:74(_message_generator)
    11081    0.006    0.000    0.009    0.000 message_serializer.py:57(__exit__)
    11080    0.006    0.000    0.171    0.000 message_serializer.py:181(<lambda>)
    11080    0.006    0.000    0.006    0.000 message_serializer.py:154(_get_decoder_func)
    11080    0.005    0.000    0.005    0.000 {built-in method _struct.unpack}
    11080    0.004    0.000    0.004    0.000 {method 'read' of '_io.BytesIO' objects}
    16629    0.003    0.000    0.003    0.000 {method 'value' of 'cimpl.Message' objects}
    16629    0.003    0.000    0.003    0.000 {method 'key' of 'cimpl.Message' objects}
    11091    0.003    0.000    0.003    0.000 {built-in method builtins.len}
    11081    0.002    0.000    0.002    0.000 {method 'close' of '_io.BytesIO' objects}
    11081    0.002    0.000    0.002    0.000 message_serializer.py:54(__enter__)
    11082    0.002    0.000    0.002    0.000 {method 'error' of 'cimpl.Message' objects}
     5540    0.002    0.000    0.002    0.000 loader.py:26(default_key_filter)
     5540    0.001    0.000    0.001    0.000 {method 'set_value' of 'cimpl.Message' objects}
     5540    0.001    0.000    0.001    0.000 {method 'set_key' of 'cimpl.Message' objects}
       42    0.001    0.000    0.001    0.000 message.py:39(__hash__)
        8    0.000    0.000    0.000    0.000 {built-in method cnamedtuple._namedtuple.namedtuple}
        8    0.000    0.000    0.000    0.000 message.py:37(message_factory)
       42    0.000    0.000    0.000    0.000 message.py:57(__repr__)
        1    0.000    0.000    0.000    0.000 {method 'assign' of 'cimpl.Consumer' objects}
        5    0.000    0.000    0.000    0.000 {method 'strftime' of 'datetime.date' objects}
```

After
====
```python
34785 function calls (34731 primitive calls) in 0.052 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     5541    0.030    0.000    0.030    0.000 {function AvroRawConsumer.poll at 0x7f528214eae8}
       17    0.007    0.000    0.047    0.003 loader.py:74(_message_generator)
     5541    0.005    0.000    0.036    0.000 consumer.py:139(poll)
     5550    0.001    0.000    0.001    0.000 {method 'error' of 'cimpl.Message' objects}
     5540    0.001    0.000    0.001    0.000 loader.py:26(default_key_filter)
     5565    0.001    0.000    0.001    0.000 {method 'value' of 'cimpl.Message' objects}
     5565    0.001    0.000    0.001    0.000 {method 'key' of 'cimpl.Message' objects}
        4    0.001    0.000    0.001    0.000 {method 'write' of '_io.TextIOWrapper' objects}
       52    0.001    0.000    0.001    0.000 message.py:39(__hash__)
        8    0.000    0.000    0.000    0.000 message.py:37(message_factory)
        8    0.000    0.000    0.000    0.000 {built-in method cnamedtuple._namedtuple.namedtuple}
       16    0.000    0.000    0.000    0.000 {built-in method fastavro._reader.read_data}
       52    0.000    0.000    0.000    0.000 message.py:57(__repr__)
        5    0.000    0.000    0.000    0.000 {method 'strftime' of 'datetime.date' objects}
       16    0.000    0.000    0.000    0.000 message_serializer.py:198(decode_message)
        2    0.000    0.000    0.000    0.000 __init__.py:251(__init__)
        1    0.000    0.000    0.000    0.000 {method 'assign' of 'cimpl.Consumer' objects}
        2    0.000    0.000    0.000    0.000 encoder.py:204(iterencode)
        3    0.000    0.000    0.002    0.001 stdlib.py:106(_proxy_to_logger)
        3    0.000    0.000    0.000    0.000 _base.py:103(_process_event)
        2    0.000    0.000    0.000    0.000 __init__.py:133(format)
        1    0.000    0.000    0.000    0.000 {method 'unassign' of 'cimpl.Consumer' objects}
       17    0.000    0.000    0.047    0.003 {built-in method builtins.next}
        8    0.000    0.000    0.001    0.000 models.py:183(apply_event)
        1    0.000    0.000    0.000    0.000 message_serializer.py:80(encode_record_with_schema)
```
