### PR TITLE
Raise exceptions on Kafka errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fyndiq/backend-developers

--- a/confluent_kafka_helpers/callbacks.py
+++ b/confluent_kafka_helpers/callbacks.py
@@ -28,7 +28,7 @@ def default_on_delivery_cb(
     if custom_cb:
         custom_cb(error, message)
     if error:
-        raise KafkaDeliveryError(str(error))
+        raise KafkaDeliveryError(str(error), message)
 
 
 def default_stats_cb(stats, custom_cb=None, send_metrics=StatsCallbackMetrics):

--- a/confluent_kafka_helpers/callbacks.py
+++ b/confluent_kafka_helpers/callbacks.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+from confluent_kafka_helpers.exceptions import KafkaDeliveryError, KafkaError
 from confluent_kafka_helpers.metrics.callbacks import (
     StatsCallbackMetrics, error_cb_metrics, on_delivery_cb_metrics
 )
@@ -17,6 +18,7 @@ def default_error_cb(error, custom_cb=None, send_metrics=error_cb_metrics):
     send_metrics(error)
     if custom_cb:
         custom_cb(error)
+    raise KafkaError(str(error))
 
 
 def default_on_delivery_cb(
@@ -25,6 +27,8 @@ def default_on_delivery_cb(
     send_metrics(error, message)
     if custom_cb:
         custom_cb(error, message)
+    if error:
+        raise KafkaDeliveryError(str(error))
 
 
 def default_stats_cb(stats, custom_cb=None, send_metrics=StatsCallbackMetrics):

--- a/confluent_kafka_helpers/exceptions.py
+++ b/confluent_kafka_helpers/exceptions.py
@@ -13,5 +13,7 @@ class KafkaError(Exception):
     pass
 
 
-class KafkaDeliveryError(Exception):
-    pass
+class KafkaDeliveryError(KafkaError):
+    def __init__(self, error: str, message):
+        self.error = error
+        self.message = message

--- a/confluent_kafka_helpers/exceptions.py
+++ b/confluent_kafka_helpers/exceptions.py
@@ -7,3 +7,11 @@ class KafkaTransportError(Exception):
     Kafka transport errors:
         - GroupCoordinator response error: Local: Broker transport failure
     """
+
+
+class KafkaError(Exception):
+    pass
+
+
+class KafkaDeliveryError(Exception):
+    pass

--- a/confluent_kafka_helpers/metrics/callbacks.py
+++ b/confluent_kafka_helpers/metrics/callbacks.py
@@ -1,27 +1,17 @@
 from functools import partial
 
-import structlog
-
 from confluent_kafka_helpers.metrics import base_metric, statsd
 from confluent_kafka_helpers.metrics.stats import StatsParser
 
-logger = structlog.get_logger(__name__)
+
+def error_cb_metrics(error, statsd=statsd):
+    statsd.event("Kafka error", str(error), alert_type='error')
 
 
-def error_cb_metrics(error, statsd=statsd, logger=logger):
-    error_msg = "Kafka error"
-    statsd.event(error_msg, str(error), alert_type='error')
-    logger.critical(error_msg, error=str(error))
-
-
-def on_delivery_cb_metrics(error, message, statsd=statsd, logger=logger):
+def on_delivery_cb_metrics(error, message, statsd=statsd):
     statsd.increment(f'{base_metric}.producer.message.count.total')
     if error:
         statsd.increment(f'{base_metric}.producer.message.count.error')
-        logger.error(
-            "Produce failed", key=message.key(), value=message.value(),
-            error=str(error)
-        )
 
 
 class StatsCallbackMetrics:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,23 +2,17 @@
 max-line-length = 80
 exclude =
     .git,
+    .eggs,
     .venv,
-    __pycache__,
-    requirements,
-    docs,
-    scripts,
+    __pycache__
 ignore = W504
 
 [coverage:run]
 branch = True
 omit =
-    .venv/*,
-    tests/*,
-    docs,
-    k8s,
-    requirements,
-    scripts,
-    node_modules/
+    .eggs,
+    .venv,
+    tests
 
 [tool:pytest]
 testpaths=tests

--- a/tests/metrics/test_callbacks.py
+++ b/tests/metrics/test_callbacks.py
@@ -8,27 +8,23 @@ from confluent_kafka_helpers.metrics.callbacks import (
 class ErrorCallbackMetricsTests:
     def test_event_should_be_sent(self):
         statsd = Mock()
-        logger = Mock()
-        error_cb_metrics('foo', statsd, logger)
+        error_cb_metrics('foo', statsd)
 
         assert statsd.event.called is True
-        assert logger.critical.called is True
 
 
 class OnDeliveryCallbackMetricsTests:
     def test_total_counter_increased(self):
         statsd = Mock()
-        on_delivery_cb_metrics(None, 'foo', statsd, Mock())
+        on_delivery_cb_metrics(None, 'foo', statsd)
 
         assert statsd.increment.called is True
 
     def test_error_counter_increased(self):
         statsd = Mock()
-        logger = Mock()
-        on_delivery_cb_metrics('error', Mock(), statsd, logger)
+        on_delivery_cb_metrics('error', Mock(), statsd)
 
         assert statsd.increment.call_count == 2
-        assert logger.error.called is True
 
 
 class StatsCallbackMetricsTests:

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -21,9 +21,7 @@ class DefaultErrorCallbackTests:
     def test_should_send_metrics(self):
         send_metrics = Mock()
         with pytest.raises(KafkaError):
-            default_error_cb(
-                None, custom_cb=Mock(), send_metrics=send_metrics
-            )
+            default_error_cb(None, custom_cb=Mock(), send_metrics=send_metrics)
         send_metrics.assert_called_once_with(None)
 
     def test_should_call_custom_callback(self):
@@ -49,23 +47,20 @@ class DefaultOnDeliveryCallbackTests:
         custom_cb.assert_called_once_with(None, 2)
 
     def test_should_raise_exception_on_error(self):
+        error, message = Mock(), Mock()
         with pytest.raises(KafkaDeliveryError):
             default_on_delivery_cb(
-                Mock(), 2, custom_cb=None, send_metrics=Mock()
+                error, message, custom_cb=None, send_metrics=Mock()
             )
 
 
 class DefaultStatsCallbackTests:
     def test_should_send_metrics(self):
         send_metrics = Mock()
-        default_stats_cb(
-            'foo', custom_cb=Mock(), send_metrics=send_metrics
-        )
+        default_stats_cb('foo', custom_cb=Mock(), send_metrics=send_metrics)
         send_metrics.assert_called_once_with('foo')
 
     def test_should_call_custom_callback(self):
         custom_cb = Mock()
-        default_stats_cb(
-            None, custom_cb=custom_cb, send_metrics=Mock()
-        )
+        default_stats_cb(None, custom_cb=custom_cb, send_metrics=Mock())
         custom_cb.assert_called_once_with(None)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,8 +1,11 @@
 from unittest.mock import Mock
 
+import pytest
+
 from confluent_kafka_helpers.callbacks import (
     default_error_cb, default_on_delivery_cb, default_stats_cb, get_callback
 )
+from confluent_kafka_helpers.exceptions import KafkaDeliveryError, KafkaError
 
 
 class GetCallBackTests:
@@ -17,14 +20,16 @@ class GetCallBackTests:
 class DefaultErrorCallbackTests:
     def test_should_send_metrics(self):
         send_metrics = Mock()
-        default_error_cb(
-            None, custom_cb=Mock(), send_metrics=send_metrics
-        )
+        with pytest.raises(KafkaError):
+            default_error_cb(
+                None, custom_cb=Mock(), send_metrics=send_metrics
+            )
         send_metrics.assert_called_once_with(None)
 
     def test_should_call_custom_callback(self):
         custom_cb = Mock()
-        default_error_cb(None, custom_cb=custom_cb, send_metrics=Mock())
+        with pytest.raises(KafkaError):
+            default_error_cb(None, custom_cb=custom_cb, send_metrics=Mock())
         custom_cb.assert_called_once_with(None)
 
 
@@ -42,6 +47,12 @@ class DefaultOnDeliveryCallbackTests:
             None, 2, custom_cb=custom_cb, send_metrics=Mock()
         )
         custom_cb.assert_called_once_with(None, 2)
+
+    def test_should_raise_exception_on_error(self):
+        with pytest.raises(KafkaDeliveryError):
+            default_on_delivery_cb(
+                Mock(), 2, custom_cb=None, send_metrics=Mock()
+            )
 
 
 class DefaultStatsCallbackTests:


### PR DESCRIPTION
## Changes
 - Raise exceptions on Kafka errors instead of just logging. Let the applications handle the errors instead (logging, Sentry)