### PR TITLE
Enable idempotence

### DIFF
--- a/confluent_kafka_helpers/producer.py
+++ b/confluent_kafka_helpers/producer.py
@@ -27,9 +27,10 @@ class AvroProducer(ConfluentAvroProducer):
     DEFAULT_CONFIG = {
         'client.id': socket.gethostname(),
         'log.connection.close': False,
-        'max.in.flight': 1,
-        'queue.buffering.max.ms': 100,
         'statistics.interval.ms': 15000,
+        'max.in.flight': 1,
+        'retries': 5,
+        'enable.idempotence': True,
     }
 
     def __init__(self, config, value_serializer=None,


### PR DESCRIPTION
## Changes
 - Enable producer idempotence

https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md

> When set to true, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must be less than or equal to 5), retries=INT32_MAX (must be greater than 0), acks=all, queuing.strategy=fifo. Producer instantation will fail if user-supplied configuration is incompatible.