### PR TITLE
Don't run sys.exit in signal handlers

### DIFF
--- a/confluent_kafka_helpers/__init__.py
+++ b/confluent_kafka_helpers/__init__.py
@@ -1,11 +1,12 @@
 """
-Default atexit registered functions will not be triggered on error signals.
+Default exit functions (atexit) will not be triggered on signals.
 
-However - if we manually handle the error signals and exit, the functions will
-be triggered.
+However - if we manually register handlers for the signals the exit functions
+are triggered correctly.
+
+NOTE! Exit functions will not be triggered on SIGKILL, SIGSTOP or os._exit()
 """
 import signal
-import sys
 
 import confluent_kafka
 import structlog
@@ -18,14 +19,11 @@ logger.debug(
 
 
 def error_handler(signum, frame):
-    logger.info("Received signal", signum=signum)
-    exit_code = 128 + signum
-    sys.exit(exit_code)
+    logger.debug("Received signal", signum=signum)
 
 
 def interrupt_handler(signum, frame):
-    logger.info("Received signal", signum=signum)
-    sys.exit(1)
+    logger.debug("Received signal", signum=signum)
 
 
 signal.signal(signal.SIGTERM, error_handler)  # graceful shutdown


### PR DESCRIPTION
## Changes
 - Don't run `sys.exit` in signal handlers since it will raise a `SystemExit` exception that's not handled properly by Gunicorn and will create a lot of unnecessary logs. The reason for using `sys.exit` was to propagate the exit code to the shell but Gunicorn always returns 0 anyways, also we don't really need to propagate it anyways so lets just remove it.

## Example log:
```
2020-09-08 18:27:00 [info     ] Received signal                [confluent_kafka_helpers] signum=15
Traceback (most recent call last):
  File "/home/simon/dev/fyndiq/fyndiq-2.0/bounded_contexts/inventory/article-api-service/.venv/lib/python3.8/site-packages/sanic/worker.py", line 82, in run
    self.loop.run_until_complete(self._check_alive())
  File "uvloop/loop.pyx", line 1450, in uvloop.loop.Loop.run_until_complete
  File "uvloop/loop.pyx", line 1443, in uvloop.loop.Loop.run_until_complete
  File "uvloop/loop.pyx", line 1351, in uvloop.loop.Loop.run_forever
  File "uvloop/loop.pyx", line 519, in uvloop.loop.Loop._run
  File "uvloop/handles/poll.pyx", line 213, in uvloop.loop.__on_uvpoll_event
  File "uvloop/cbhandles.pyx", line 90, in uvloop.loop.Handle._run
  File "uvloop/cbhandles.pyx", line 73, in uvloop.loop.Handle._run
  File "uvloop/loop.pyx", line 359, in uvloop.loop.Loop._read_from_self
  File "uvloop/loop.pyx", line 364, in uvloop.loop.Loop._invoke_signals
  File "uvloop/loop.pyx", line 339, in uvloop.loop.Loop._ceval_process_signals
  File "/home/simon/dev/fyndiq/confluent_kafka_helpers/confluent_kafka_helpers/__init__.py", line 21, in error_handler
    logger.info("Received signal", signum=signum)
  File "/home/simon/dev/fyndiq/fyndiq-2.0/bounded_contexts/inventory/article-api-service/.venv/lib/python3.8/site-packages/structlog/stdlib.py", line 74, in info
    return self._proxy_to_logger("info", event, *args, **kw)
  File "/home/simon/dev/fyndiq/fyndiq-2.0/bounded_contexts/inventory/article-api-service/.venv/lib/python3.8/site-packages/structlog/stdlib.py", line 123, in _proxy_to_logger
    return super(BoundLogger, self)._proxy_to_logger(
  File "/home/simon/dev/fyndiq/fyndiq-2.0/bounded_contexts/inventory/article-api-service/.venv/lib/python3.8/site-packages/structlog/_base.py", line 190, in _proxy_to_logger
    return getattr(self._logger, method_name)(*args, **kw)
  File "/usr/lib/python3.8/logging/__init__.py", line 1434, in info
    self._log(INFO, msg, args, **kwargs)
  File "/usr/lib/python3.8/logging/__init__.py", line 1577, in _log
    self.handle(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 1587, in handle
    self.callHandlers(record)
  File "/home/simon/dev/fyndiq/fyndiq-2.0/bounded_contexts/inventory/article-api-service/.venv/lib/python3.8/site-packages/sentry_sdk/integrations/logging.py", line 83, in sentry_patched_callhandlers
    return old_callhandlers(self, record)
  File "/usr/lib/python3.8/logging/__init__.py", line 1649, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 950, in handle
    self.emit(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 1081, in emit
    msg = self.format(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 925, in format
    return fmt.format(record)
  File "/home/simon/dev/fyndiq/fyndiq-2.0/bounded_contexts/inventory/article-api-service/.venv/lib/python3.8/site-packages/structlog/stdlib.py", line 552, in format
    record.msg = self.processor(logger, meth_name, ed)
  File "/home/simon/dev/fyndiq/fyndiq-2.0/bounded_contexts/inventory/article-api-service/.venv/lib/python3.8/site-packages/structlog/dev.py", line 202, in __call__
    sio.write(
  File "/home/simon/dev/fyndiq/confluent_kafka_helpers/confluent_kafka_helpers/__init__.py", line 23, in error_handler
    sys.exit(exit_code)
SystemExit: 143
2020-09-08 18:27:00 [info     ] Flushing producer              [confluent_kafka_helpers.producer]
```
