### PR TITLE
consumer: set default auto.offset.reset to earliest

### DIFF
--- a/confluent_kafka_helpers/consumer.py
+++ b/confluent_kafka_helpers/consumer.py
@@ -54,7 +54,7 @@ class AvroConsumer:
     DEFAULT_CONFIG = {
         'client.id': socket.gethostname(),
         'default.topic.config': {
-            'auto.offset.reset': 'latest'
+            'auto.offset.reset': 'earliest'
         },
         'enable.auto.commit': False,
         'fetch.error.backoff.ms': 0,


### PR DESCRIPTION
## Changes
 - Change default `auto.offset.reset` strategy to `earliest` instead of `latest`. Using `latest` could trigger "skipped messages" behavior on exceptions in services that subscribes to topics that yet doesn't have messages on all partitions. Using `earliest` will make sure the service doesn't skip any messages, we just have to be careful not to accidentally change consumer groups.