### PR TITLE
Use existing signal handlers if they exist

### DIFF
--- a/confluent_kafka_helpers/__init__.py
+++ b/confluent_kafka_helpers/__init__.py
@@ -1,12 +1,13 @@
 """
 Default exit functions (atexit) will not be triggered on signals.
 
-However - if we manually register handlers for the signals the exit functions
+However - if we manually register handlers and `sys.exit()` the exit functions
 are triggered correctly.
 
 NOTE! Exit functions will not be triggered on SIGKILL, SIGSTOP or os._exit()
 """
 import signal
+import sys
 
 import confluent_kafka
 import structlog
@@ -17,14 +18,33 @@ logger.debug(
     libversion=confluent_kafka.libversion()
 )
 
+existing_termination_handler = signal.getsignal(signal.SIGTERM)
+existing_interrupt_handler = signal.getsignal(signal.SIGINT)
 
-def error_handler(signum, frame):
-    logger.debug("Received signal", signum=signum)
+
+def termination_handler(signum, frame):
+    logger.debug("Received termination signal", signum=signum)
+    if existing_termination_handler:
+        logger.debug(
+            "Using existing termination handler",
+            name=existing_termination_handler.__qualname__
+        )
+        existing_termination_handler(signum, frame)
+    else:
+        sys.exit(0)
 
 
 def interrupt_handler(signum, frame):
-    logger.debug("Received signal", signum=signum)
+    logger.debug("Received interrupt signal", signum=signum)
+    if existing_interrupt_handler:
+        logger.debug(
+            "Using existing interrupt handler",
+            name=existing_interrupt_handler.__qualname__
+        )
+        existing_interrupt_handler(signum, frame)
+    else:
+        sys.exit(0)
 
 
-signal.signal(signal.SIGTERM, error_handler)  # graceful shutdown
-signal.signal(signal.SIGINT, interrupt_handler)  # keyboard interrupt
+signal.signal(signal.SIGTERM, termination_handler)
+signal.signal(signal.SIGINT, interrupt_handler)


### PR DESCRIPTION
## Changes
 - Currently we override already registered signal handlers (for example uvloop used by Sanic). If there's already a registered handler for a signal we should use it instead.