### PR TITLE
Update default configs

### DIFF
--- a/confluent_kafka_helpers/consumer.py
+++ b/confluent_kafka_helpers/consumer.py
@@ -57,14 +57,9 @@ class AvroConsumer:
             'auto.offset.reset': 'earliest'
         },
         'enable.auto.commit': False,
-        'fetch.error.backoff.ms': 0,
-        'fetch.wait.max.ms': 100,
-        'fetch.min.bytes': 1000,
+        'fetch.wait.max.ms': 1000,
         'log.connection.close': False,
         'log.thread.name': False,
-        'statistics.interval.ms': 15000,
-        'queued.max.messages.kbytes': '10485',
-        'fetch.message.max.bytes': '10485',
     }
 
     def __init__(

--- a/confluent_kafka_helpers/metrics/statistics.py
+++ b/confluent_kafka_helpers/metrics/statistics.py
@@ -10,7 +10,6 @@ def send_metric(base, metric, stats, tags):
         return
     value = stats.get(metric)
     name = f'{base}.{metric}'
-    logger.debug("Sending metric", name=name, value=value, tags=tags)
     statsd.gauge(name, value, tags=tags)
 
 

--- a/confluent_kafka_helpers/producer.py
+++ b/confluent_kafka_helpers/producer.py
@@ -27,9 +27,7 @@ class AvroProducer(ConfluentAvroProducer):
     DEFAULT_CONFIG = {
         'client.id': socket.gethostname(),
         'log.connection.close': False,
-        'statistics.interval.ms': 15000,
-        'max.in.flight': 1,
-        'retries': 5,
+        'retries': 5,  # remove in 1.5.2
         'enable.idempotence': True,
     }
 


### PR DESCRIPTION
## Changes
 - Update default consumer and producer configurations
    - (consumer) `fetch.wait.max.ms`, `fetch.error.backoff.ms`, `fetch.min.bytes`: These values was previously optimized for latency but since we don't use event sourcing or have any critical user facing systems that rely on Kafka anymore this is not as important. The low current values generates a lot of unnecessary fetch requests that cause high CPU load on the brokers.
   - (consumer) `queued.max.messages.kbytes`, `fetch.message.max.bytes`: These values was previously overridden because the default values used to be insanely high (1GB per topic/partition) which caused our consumers to go OOM when consuming from the beginning in a new consumer group. These values now have sane default values so no reason to override them anymore.
   - (consumer, producer): `statistics.interval.ms`: Use the default value of 0 to disable the statistics callback.
   - (producer): `max.in.flight`: Since we have idempotent producers enabled this configuration is not important anymore. It was set to 1 before to prohibit out-of-order messages. https://github.com/edenhill/librdkafka/blob/master/INTRODUCTION.md#reordering
 - Remove statistics debug logger