### PR TITLE
Add feature flag for sending metrics to datadog

### DIFF
--- a/confluent_kafka_helpers/metrics/__init__.py
+++ b/confluent_kafka_helpers/metrics/__init__.py
@@ -1,3 +1,5 @@
+from os import getenv
+
 base_metric = 'confluent_kafka_helpers'
 
 
@@ -25,7 +27,10 @@ class TimedNullDecorator:
 
 
 try:
-    import datadog
-    statsd = datadog.statsd
+    if getenv('DATADOG_ENABLE_METRICS') != '1':
+        statsd = StatsdNullClient()  # type: ignore
+    else:
+        import datadog
+        statsd = datadog.statsd
 except ModuleNotFoundError:
     statsd = StatsdNullClient()  # type: ignore


### PR DESCRIPTION
Changes:
- Add feature flag environment variable DATADOG_ENABLE_METRICS that toggles sending metics to Datadog. Disable by default.