### PR TITLE
Fix inject headers

### DIFF
--- a/tests/tracing/backends/test_opentracer.py
+++ b/tests/tracing/backends/test_opentracer.py
@@ -134,7 +134,7 @@ def test_inject_headers_and_start_span_pass_correct_kwargs(opentracer):
             },
         }
         opentracer._tracer.start_span.assert_called_once_with(**expected_start_span_kwargs)
-        active_span = opentracer._tracer.active_span
+        active_span = opentracer._tracer.start_span.return_value
         expected_inject_kwargs = {
             'span_context': active_span.context,
             'carrier': {'foo': 'bar'},


### PR DESCRIPTION
## Changes
 - Fix `inject_headers_and_start_span` to always return a span and thus a span context. Currently it crashes because `span` is empty when tracing is disabled and raising an `AttributeError` when accessing `span.context`. 