### PR TITLE
Upgrade confluent-kafka-python to 1.6.1

### DIFF
--- a/confluent_kafka_helpers/exceptions.py
+++ b/confluent_kafka_helpers/exceptions.py
@@ -1,5 +1,5 @@
 class EndOfPartition(Exception):
-    """ We have reached the end of a partition """
+    """We have reached the end of a partition"""
 
 
 class KafkaTransportError(Exception):

--- a/requirements.in
+++ b/requirements.in
@@ -14,6 +14,4 @@ pytest-mock
 structlog
 
 opentracing>=2.4.0
-avro-python3>=1.8.2,<=1.10.0
-confluent-kafka>=1.0.0,<=1.5.0
-fastavro>=0.18.0,<=1.0.0.post1
+confluent-kafka[avro]>=1.0.0,<=1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,15 +6,17 @@
 #
 appdirs==1.4.4
     # via black
-attrs==20.3.0
+appnope==0.1.2
+    # via ipython
+attrs==21.1.0
     # via
     #   flake8-eradicate
     #   pytest
 avro-python3==1.10.0
-    # via -r requirements.in
+    # via confluent-kafka
 backcall==0.2.0
     # via ipython
-black==20.8b1
+black==21.5b0
     # via flake8-black
 certifi==2020.12.5
     # via requests
@@ -26,7 +28,7 @@ click==7.1.2
     #   pip-tools
 codecov==2.1.9
     # via -r requirements.in
-confluent-kafka==1.5.0
+confluent-kafka[avro]==1.6.1
     # via -r requirements.in
 coverage==5.5
     # via
@@ -38,8 +40,8 @@ eradicate==2.0.0
     # via flake8-eradicate
 fancycompleter==0.9.1
     # via pdbpp
-fastavro==1.0.0.post1
-    # via -r requirements.in
+fastavro==1.4.0
+    # via confluent-kafka
 flake8-black==0.2.1
     # via -r requirements.in
 flake8-eradicate==1.0.0
@@ -62,11 +64,13 @@ ipdb==0.13.7
     # via -r requirements.in
 ipython-genutils==0.2.0
     # via traitlets
-ipython==7.22.0
+ipython==7.23.1
     # via ipdb
 isort==5.8.0
     # via flake8-isort
 jedi==0.18.0
+    # via ipython
+matplotlib-inline==0.1.2
     # via ipython
 mccabe==0.6.1
     # via flake8
@@ -108,7 +112,7 @@ pycodestyle==2.7.0
     # via flake8
 pyflakes==2.3.1
     # via flake8
-pygments==2.8.1
+pygments==2.9.0
     # via
     #   ipython
     #   pdbpp
@@ -124,9 +128,9 @@ pytest-coverage==0.0
     # via -r requirements.in
 pytest-icdiff==0.5
     # via -r requirements.in
-pytest-mock==3.5.1
+pytest-mock==3.6.1
     # via -r requirements.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -135,7 +139,9 @@ pytest==6.2.3
 regex==2021.4.4
     # via black
 requests==2.25.1
-    # via codecov
+    # via
+    #   codecov
+    #   confluent-kafka
 structlog==21.1.0
     # via -r requirements.in
 testfixtures==6.17.1
@@ -147,20 +153,18 @@ toml==0.10.2
     #   pep517
     #   pytest
 traitlets==5.0.5
-    # via ipython
+    # via
+    #   ipython
+    #   matplotlib-inline
 typed-ast==1.4.3
-    # via
-    #   black
-    #   mypy
-typing-extensions==3.7.4.3
-    # via
-    #   black
-    #   mypy
+    # via mypy
+typing-extensions==3.10.0.0
+    # via mypy
 urllib3==1.26.4
     # via requests
 wcwidth==0.2.5
     # via prompt-toolkit
-wmctrl==0.3
+wmctrl==0.4
     # via pdbpp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="confluent-kafka-helpers",
-    version="0.8.0",
+    version="0.9.0",
     description="Helpers for Confluent's Kafka Python client",
     url="https://github.com/fyndiq/confluent_kafka_helpers",
     author="Fyndiq AB",
@@ -12,9 +12,7 @@ setup(
     setup_requires=['wheel'],
     install_requires=[
         'structlog>=17.2.0',
-        'confluent-kafka>=1.0.0,<=1.5.0',
-        'fastavro>=0.18.0,<=1.0.0.post1',
-        'avro-python3>=1.8.2,<=1.10.0',
+        'confluent-kafka[avro]>=1.0.0,<=1.6.1',
     ],
     extras_require={'opentracing': 'opentracing>=2.4.0'},
     zip_safe=False,


### PR DESCRIPTION
**Background**
Routine upgrade of confluent-kafka-python. The idea for the bump here came from a discussion on building a python 3.9 image on our https://github.com/fyndiq/python-confluent-kafka image. This is not necessary but seems reasonable to do both at once.

**Changes**
- Upgrade confluent-kafka-python to 1.6.1
- Remove avro-python3 and fastavro from requirements.in and setup.py and instead use `confluent-kafka-python[avro]`.
    - The advantage here is that we don't need to track the version constraint on those dependencies and instead let confluent-kafka-python handle it (https://github.com/confluentinc/confluent-kafka-python/blob/master/setup.py#L28-L33).

Could use a second opinion on the later, please let me know if you have any concerns.