### PR TITLE
Pin versions of confluent-kafka dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,4 +14,6 @@ pytest-mock
 structlog
 
 opentracing>=2.4.0
-confluent-kafka[avro]>=1.0.0,<=1.6.1
+confluent-kafka>=1.0.0,<=1.6.1
+avro-python3>=1.8.2,<=1.10.0
+fastavro>=0.18.0,<=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ attrs==21.1.0
     #   flake8-eradicate
     #   pytest
 avro-python3==1.10.0
-    # via confluent-kafka
+    # via -r requirements.in
 backcall==0.2.0
     # via ipython
 black==21.5b0
@@ -28,7 +28,7 @@ click==7.1.2
     #   pip-tools
 codecov==2.1.9
     # via -r requirements.in
-confluent-kafka[avro]==1.6.1
+confluent-kafka==1.6.1
     # via -r requirements.in
 coverage==5.5
     # via
@@ -40,8 +40,8 @@ eradicate==2.0.0
     # via flake8-eradicate
 fancycompleter==0.9.1
     # via pdbpp
-fastavro==1.4.0
-    # via confluent-kafka
+fastavro==1.1.0
+    # via -r requirements.in
 flake8-black==0.2.1
     # via -r requirements.in
 flake8-eradicate==1.0.0
@@ -139,9 +139,7 @@ pytest==6.2.4
 regex==2021.4.4
     # via black
 requests==2.25.1
-    # via
-    #   codecov
-    #   confluent-kafka
+    # via codecov
 structlog==21.1.0
     # via -r requirements.in
 testfixtures==6.17.1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ setup(
     setup_requires=['wheel'],
     install_requires=[
         'structlog>=17.2.0',
-        'confluent-kafka[avro]>=1.0.0,<=1.6.1',
+        'confluent-kafka>=1.0.0,<=1.6.1',
+        'fastavro>=0.18.0,<=1.1.0',
+        'avro-python3>=1.8.2,<=1.10.0',
     ],
     extras_require={'opentracing': 'opentracing>=2.4.0'},
     zip_safe=False,


### PR DESCRIPTION
**Background**

This follows up (partially) on the comments from #63. We go back to the pinning version of the dependencies of confluent-kafka[avro]. See the discussion on the PR for reasoning.

The only difference from pre-#63 is that we bumped fastavro upper limit to 1.1.0. The reason for that is to support python 3.9. The bump seems to be safe as per https://github.com/fastavro/fastavro/blob/master/ChangeLog
> * Dropped support for Python 3.5 and added support Python 3.9 (PR #474)