### PR TITLE
Add logger params and pass forward kwargs to consumer/producer

### DIFF
--- a/confluent_kafka_helpers/consumer.py
+++ b/confluent_kafka_helpers/consumer.py
@@ -63,6 +63,7 @@ class AvroConsumer:
         config,
         get_message: Callable = get_message,
         error_handler: Callable = default_error_handler,
+        **kwargs,
     ) -> None:
         stop_on_eof = config.pop('stop_on_eof', False)
         poll_timeout = config.pop('poll_timeout', 0.1)
@@ -74,7 +75,7 @@ class AvroConsumer:
         self.topics = self._get_topics(self.config)
 
         logger.info("Initializing consumer", config=self.config)
-        self.consumer = ConfluentAvroConsumer(self.config)
+        self.consumer = ConfluentAvroConsumer(self.config, **kwargs)
         self.consumer.subscribe(self.topics)
 
         self._generator = self._message_generator()

--- a/confluent_kafka_helpers/producer.py
+++ b/confluent_kafka_helpers/producer.py
@@ -40,6 +40,7 @@ class AvroProducer(ConfluentAvroProducer):
         value_serializer=None,
         schema_registry=AvroSchemaRegistry,
         get_callback=get_callback,
+        **kwargs,
     ):
         config = {**self.DEFAULT_CONFIG, **config}
         config['on_delivery'] = get_callback(
@@ -62,7 +63,7 @@ class AvroProducer(ConfluentAvroProducer):
         logger.info("Initializing producer", config=config)
         atexit.register(self._close)
 
-        super().__init__(config)
+        super().__init__(config, **kwargs)
 
     def _close(self):
         logger.info("Flushing producer")


### PR DESCRIPTION
**Background**

I thought about passing the logger explicity since that's the main use-case here but I've decided to follow the implementation in confluent_kafka and just pass forward `**kwargs`. Hopefully this will be helpful in other situations too.

https://github.com/confluentinc/confluent-kafka-python/blob/97f08fe107d259eff6f9c281a61d92e204d2935d/src/confluent_kafka/avro/__init__.py#L47

**Changes**
- Pass forward `**kwargs` on AvroConsumer/AvroProducer