### PR TITLE
Update default config for provider to better fit with enable.idempotence

### DIFF
--- a/confluent_kafka_helpers/producer.py
+++ b/confluent_kafka_helpers/producer.py
@@ -29,8 +29,8 @@ class AvroProducer(ConfluentAvroProducer):
     DEFAULT_CONFIG = {
         'client.id': socket.gethostname(),
         'log.connection.close': False,
-        'retries': 5,  # remove in 1.5.2
         'enable.idempotence': True,
+        'max.in.flight': 1,
         'linger.ms': 1000,
     }
 


### PR DESCRIPTION
**Background**

Since idempotence is enabled it makes sense to adjust the related values as per https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md

**Changes**
- Changes to the producer default config to better work with idempotence