### PR TITLE
Raise `confluent-kafka` pin to `<=1.7.0`

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,6 +14,6 @@ pytest-mock
 structlog
 
 opentracing>=2.4.0
-confluent-kafka>=1.0.0,<=1.6.1
+confluent-kafka>=1.0.0,<=1.7.0
 avro-python3>=1.8.2,<=1.10.0
 fastavro>=0.18.0,<=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 appdirs==1.4.4
     # via black
-attrs==21.1.0
+attrs==21.2.0
     # via
     #   flake8-eradicate
     #   pytest
@@ -14,39 +14,41 @@ avro-python3==1.10.0
     # via -r requirements.in
 backcall==0.2.0
     # via ipython
-black==21.5b0
+black==21.7b0
     # via flake8-black
-certifi==2020.12.5
+certifi==2021.5.30
     # via requests
-chardet==4.0.0
+charset-normalizer==2.0.3
     # via requests
-click==7.1.2
+click==8.0.1
     # via
     #   black
     #   pip-tools
 codecov==2.1.9
     # via -r requirements.in
-confluent-kafka==1.6.1
+confluent-kafka==1.7.0
     # via -r requirements.in
 coverage==5.5
     # via
     #   codecov
     #   pytest-cov
-decorator==5.0.7
-    # via ipython
+decorator==5.0.9
+    # via
+    #   ipdb
+    #   ipython
 eradicate==2.0.0
     # via flake8-eradicate
 fancycompleter==0.9.1
     # via pdbpp
 fastavro==1.1.0
     # via -r requirements.in
-flake8-black==0.2.1
+flake8-black==0.2.3
     # via -r requirements.in
-flake8-eradicate==1.0.0
+flake8-eradicate==1.1.0
     # via -r requirements.in
 flake8-isort==4.0.0
     # via -r requirements.in
-flake8==3.9.1
+flake8==3.9.2
     # via
     #   -r requirements.in
     #   flake8-black
@@ -54,17 +56,17 @@ flake8==3.9.1
     #   flake8-isort
 icdiff==1.9.1
     # via pytest-icdiff
-idna==2.10
+idna==3.2
     # via requests
 iniconfig==1.1.1
     # via pytest
-ipdb==0.13.7
+ipdb==0.13.9
     # via -r requirements.in
 ipython-genutils==0.2.0
     # via traitlets
-ipython==7.23.1
+ipython==7.25.0
     # via ipdb
-isort==5.8.0
+isort==5.9.2
     # via flake8-isort
 jedi==0.18.0
     # via ipython
@@ -76,31 +78,31 @@ mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
-mypy==0.812
+mypy==0.910
     # via -r requirements.in
 opentracing==2.4.0
     # via -r requirements.in
-packaging==20.9
+packaging==21.0
     # via pytest
 parso==0.8.2
     # via jedi
-pathspec==0.8.1
+pathspec==0.9.0
     # via black
-pdbpp==0.10.2
+pdbpp==0.10.3
     # via -r requirements.in
-pep517==0.10.0
+pep517==0.11.0
     # via pip-tools
 pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.1.0
+pip-tools==6.2.0
     # via -r requirements.in
 pluggy==0.13.1
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-prompt-toolkit==3.0.18
+prompt-toolkit==3.0.19
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -118,7 +120,7 @@ pyparsing==2.4.7
     # via packaging
 pyrepl==0.9.0
     # via fancycompleter
-pytest-cov==2.11.1
+pytest-cov==2.12.1
     # via pytest-cover
 pytest-cover==3.0.0
     # via pytest-coverage
@@ -134,32 +136,37 @@ pytest==6.2.4
     #   pytest-cov
     #   pytest-icdiff
     #   pytest-mock
-regex==2021.4.4
+regex==2021.7.6
     # via black
-requests==2.25.1
+requests==2.26.0
     # via codecov
 structlog==21.1.0
     # via -r requirements.in
-testfixtures==6.17.1
+testfixtures==6.18.0
     # via flake8-isort
 toml==0.10.2
     # via
-    #   black
+    #   flake8-black
     #   ipdb
-    #   pep517
+    #   mypy
     #   pytest
+    #   pytest-cov
+tomli==1.0.4
+    # via
+    #   black
+    #   pep517
 traitlets==5.0.5
     # via
     #   ipython
     #   matplotlib-inline
-typed-ast==1.4.3
-    # via mypy
 typing-extensions==3.10.0.0
     # via mypy
-urllib3==1.26.5
+urllib3==1.26.6
     # via requests
 wcwidth==0.2.5
     # via prompt-toolkit
+wheel==0.36.2
+    # via pip-tools
 wmctrl==0.4
     # via pdbpp
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="confluent-kafka-helpers",
-    version="0.9.0",
+    version="0.10.0",
     description="Helpers for Confluent's Kafka Python client",
     url="https://github.com/fyndiq/confluent_kafka_helpers",
     author="Fyndiq AB",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     setup_requires=['wheel'],
     install_requires=[
         'structlog>=17.2.0',
-        'confluent-kafka>=1.0.0,<=1.6.1',
+        'confluent-kafka>=1.0.0,<=1.7.0',
         'fastavro>=0.18.0,<=1.1.0',
         'avro-python3>=1.8.2,<=1.10.0',
     ],


### PR DESCRIPTION
Compared to last time (https://github.com/fyndiq/confluent_kafka_helpers/pull/63) this upgrade has fewer features/changes that seem applicable our use cases:

https://github.com/confluentinc/confluent-kafka-python/blob/master/CHANGELOG.md#v170
https://github.com/edenhill/librdkafka/releases/tag/v1.7.0
