### PR TITLE
Close scope after finishing span in start_active_span to stop memory leak

### DIFF
--- a/confluent_kafka_helpers/tracing/backends/opentracer.py
+++ b/confluent_kafka_helpers/tracing/backends/opentracer.py
@@ -36,6 +36,7 @@ class OpenTracerBackend:
             if scope:
                 self.log_exception(span=scope.span)
                 scope.span.finish()
+                scope.close()
 
     @contextlib.contextmanager
     def start_span(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="confluent-kafka-helpers",
-    version="0.10.0",
+    version="0.10.1",
     description="Helpers for Confluent's Kafka Python client",
     url="https://github.com/fyndiq/confluent_kafka_helpers",
     author="Fyndiq AB",


### PR DESCRIPTION
We have experienced a memory leak for our Kafka consumers and some investigation shows that for each Kafka message we consumed we leaked the following amount of objects (results from `objgraph.show_growth()` [ref](https://mg.pov.lt/objgraph/objgraph.html#objgraph.show_growth))

```
dict                  6959        +3
Span                     9        +2
list                  2137        +1
SpanContext              4        +1
_ContextVarsScope        3        +1
Token                    3        +1
```

This kept increasing until the consumer ran out of memory.

Adding a `scope.close()` as presented in this PR stopped the memory leak.

Trying this change in production shows that the tracing in Datadog functions the same way as before this change but without the memory leaks.