### PR TITLE
fix: removes schema registry extra dependency 

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,4 +15,4 @@ twine
 
 opentelemetry-api==1.27.0
 opentelemetry-semantic-conventions==0.48b0  # 0.48b0 == 1.27.0
-confluent-kafka[avro,schema-registry]==2.*
+confluent-kafka[avro]==2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,35 +4,39 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements.txt requirements.in
 #
-attrs==24.2.0
+anyio==4.8.0
+    # via httpx
+attrs==25.1.0
     # via
+    #   confluent-kafka
     #   flake8-eradicate
     #   wmctrl
 avro==1.12.0
     # via confluent-kafka
 backports-tarfile==1.2.0
     # via jaraco-context
-black==24.8.0
+black==25.1.0
     # via flake8-black
-build==1.2.2
+build==1.2.2.post1
     # via pip-tools
-certifi==2024.8.30
+cachetools==5.5.1
+    # via confluent-kafka
+certifi==2025.1.31
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+charset-normalizer==3.4.1
     # via requests
-cffi==1.17.1
-    # via cryptography
-charset-normalizer==3.3.2
-    # via requests
-click==8.1.7
+click==8.1.8
     # via
     #   black
     #   pip-tools
-confluent-kafka[avro,schema-registry]==2.5.3
+confluent-kafka[avro,schema-registry]==2.8.0
     # via -r requirements.in
-coverage[toml]==7.6.1
+coverage[toml]==7.6.12
     # via pytest-cov
-cryptography==43.0.1
-    # via secretstorage
-deprecated==1.2.14
+deprecated==1.2.18
     # via
     #   opentelemetry-api
     #   opentelemetry-semantic-conventions
@@ -41,10 +45,12 @@ docutils==0.21.2
 eradicate==2.3.0
     # via flake8-eradicate
 exceptiongroup==1.2.2
-    # via pytest
+    # via
+    #   anyio
+    #   pytest
 fancycompleter==0.9.1
     # via pdbpp
-fastavro==1.9.7
+fastavro==1.10.0
     # via confluent-kafka
 flake8==7.1.1
     # via
@@ -56,32 +62,38 @@ flake8-black==0.3.6
     # via -r requirements.in
 flake8-eradicate==1.5.0
     # via -r requirements.in
-flake8-isort==6.1.1
+flake8-isort==6.1.2
     # via -r requirements.in
+h11==0.14.0
+    # via httpcore
+httpcore==1.0.7
+    # via httpx
+httpx==0.28.1
+    # via confluent-kafka
 icdiff==2.0.7
     # via pytest-icdiff
+id==1.5.0
+    # via twine
 idna==3.10
-    # via requests
+    # via
+    #   anyio
+    #   httpx
+    #   requests
 importlib-metadata==8.4.0
     # via
     #   keyring
     #   opentelemetry-api
-    #   twine
 iniconfig==2.0.0
     # via pytest
-isort==5.13.2
+isort==6.0.0
     # via flake8-isort
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.0.1
     # via keyring
-jaraco-functools==4.0.2
+jaraco-functools==4.1.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
-keyring==25.4.1
+keyring==25.6.0
     # via twine
 markdown-it-py==3.0.0
     # via rich
@@ -89,17 +101,17 @@ mccabe==0.7.0
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.5.0
+more-itertools==10.6.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-mypy==1.11.2
+mypy==1.15.0
     # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-nh3==0.2.18
+nh3==0.2.20
     # via readme-renderer
 opentelemetry-api==1.27.0
     # via
@@ -107,19 +119,18 @@ opentelemetry-api==1.27.0
     #   opentelemetry-semantic-conventions
 opentelemetry-semantic-conventions==0.48b0
     # via -r requirements.in
-packaging==24.1
+packaging==24.2
     # via
     #   black
     #   build
     #   pytest
+    #   twine
 pathspec==0.12.1
     # via black
 pdbpp==0.10.3
     # via -r requirements.in
 pip-tools==7.4.1
     # via -r requirements.in
-pkginfo==1.10.0
-    # via twine
 platformdirs==4.3.6
     # via black
 pluggy==1.5.0
@@ -128,28 +139,26 @@ pprintpp==0.4.0
     # via pytest-icdiff
 pycodestyle==2.12.1
     # via flake8
-pycparser==2.22
-    # via cffi
 pyflakes==3.2.0
     # via flake8
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   pdbpp
     #   readme-renderer
     #   rich
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
 pyrepl==0.9.0
     # via fancycompleter
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   -r requirements.in
     #   pytest-cov
     #   pytest-icdiff
     #   pytest-mock
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via pytest-cover
 pytest-cover==3.0.0
     # via pytest-coverage
@@ -164,19 +173,20 @@ readme-renderer==44.0
 requests==2.32.3
     # via
     #   confluent-kafka
+    #   id
     #   requests-toolbelt
     #   twine
 requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.8.1
+rich==13.9.4
     # via twine
-secretstorage==3.3.3
-    # via keyring
-structlog==24.4.0
+sniffio==1.3.1
+    # via anyio
+structlog==25.1.0
     # via -r requirements.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   black
     #   build
@@ -185,29 +195,32 @@ tomli==2.0.1
     #   mypy
     #   pip-tools
     #   pytest
-twine==5.1.1
+twine==6.1.0
     # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   anyio
     #   black
     #   mypy
-urllib3==2.2.3
+    #   rich
+    #   structlog
+urllib3==2.3.0
     # via
     #   requests
     #   twine
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools
 wmctrl==0.5
     # via pdbpp
-wrapt==1.16.0
+wrapt==1.17.2
     # via deprecated
-zipp==3.20.2
+zipp==3.21.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2
+pip==25.0.1
     # via
     #   -r requirements.in
     #   pip-tools
-setuptools==75.1.0
+setuptools==75.8.0
     # via pip-tools

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="confluent-kafka-helpers",
-    version="1.0.1",
+    version="1.0.2",
     description="Helpers for Confluent's Kafka Python client",
     url="https://github.com/fyndiq/confluent_kafka_helpers",
     author="Fyndiq AB",
@@ -12,7 +12,7 @@ setup(
     setup_requires=['wheel'],
     install_requires=[
         'structlog>=17.2.0',
-        'confluent-kafka[avro,schema-registry]==2.*',
+        'confluent-kafka[avro]==2.*',
         'opentelemetry-api==1.27.0',
         'opentelemetry-semantic-conventions==0.48b0',  # 1.27.0
     ],


### PR DESCRIPTION
avrocat fails due to the extra requirement for schema-registry that does not exist anymore