### PR TITLE
fix: unify handling of existing signal handlers

### DIFF
--- a/confluent_kafka_helpers/__init__.py
+++ b/confluent_kafka_helpers/__init__.py
@@ -28,7 +28,8 @@ def termination_handler(signum, frame):
     logger.debug("Received termination signal", signum=signum)
     if existing_termination_handler:
         logger.debug(
-            "Using existing termination handler", name=existing_termination_handler.__qualname__
+            "Using existing termination handler",
+            name=existing_termination_handler.__qualname__,
         )
         existing_termination_handler(signum, frame)
     else:
@@ -37,9 +38,10 @@ def termination_handler(signum, frame):
 
 def interrupt_handler(signum, frame):
     logger.debug("Received interrupt signal", signum=signum)
-    if existing_interrupt_handler is not signal.default_int_handler:
+    if existing_interrupt_handler:
         logger.debug(
-            "Using existing interrupt handler", name=existing_interrupt_handler.__qualname__
+            "Using existing interrupt handler",
+            name=existing_interrupt_handler.__qualname__,
         )
         existing_interrupt_handler(signum, frame)
     else:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="confluent-kafka-helpers",
-    version="1.0.2",
+    version="1.0.3",
     description="Helpers for Confluent's Kafka Python client",
     url="https://github.com/fyndiq/confluent_kafka_helpers",
     author="Fyndiq AB",


### PR DESCRIPTION
## Background

Currently, we get these errors when interrupting eg. FastAPI:

```
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/home/simon/dev/fyndiq/fyndiq-2.0/bounded_contexts/inventory/article-handler-service/.venv/lib/python3.12/site-packages/uvicorn/workers.py", line 102, in _serve
    await server.serve(sockets=self.sockets)
  File "/home/simon/dev/fyndiq/fyndiq-2.0/bounded_contexts/inventory/article-handler-service/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 69, in serve
    with self.capture_signals():
  File "/home/simon/.pyenv/versions/3.12.4/lib/python3.12/contextlib.py", line 144, in __exit__
    next(self.gen)
  File "/home/simon/dev/fyndiq/fyndiq-2.0/bounded_contexts/inventory/article-handler-service/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 330, in capture_signals
    signal.raise_signal(captured_signal)
  File "/home/simon/dev/fyndiq/fyndiq-2.0/bounded_contexts/inventory/article-handler-service/.venv/lib/python3.12/site-packages/confluent_kafka_helpers/__init__.py", line 42, in interrupt_handler
    "Using existing interrupt handler", name=existing_interrupt_handler.__qualname__
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Handlers' object has no attribute '__qualname__'
```
This is because the default signal handler for SIGINT doesn't have a `__qualname__` method. To fix this, we handle SIGINT the same way we handle SIGTERM. Instead of doing an `in` comparison, we check if there is a default handler at all.


## Changes

- Unify handling of SIGINT and SIGTERM 