### PR TITLE
feat: add support for automatic header propagation

### DIFF
--- a/confluent_kafka_helpers/context.py
+++ b/confluent_kafka_helpers/context.py
@@ -1,0 +1,16 @@
+import contextvars
+from typing import Any
+
+_headers: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar("headers", default={})
+
+
+def set_propagated_headers(headers: dict[str, Any]):
+    _headers.set(headers)
+
+
+def get_propagated_headers() -> dict[str, Any]:
+    return _headers.get()
+
+
+def clear_propagated_headers():
+    _headers.set({})

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="confluent-kafka-helpers",
-    version="1.0.3",
+    version="1.1.0",
     description="Helpers for Confluent's Kafka Python client",
     url="https://github.com/fyndiq/confluent_kafka_helpers",
     author="Fyndiq AB",


### PR DESCRIPTION
## Changes

- Add support for automatic propagation of some certain headers specified in the new consumer config `headers.propagate`. This is very useful when shuffling the same header around in multiple services. The context is async/thread safe so should be safe to use in any application.

## Example usage

```python

from confluent_kafka_helpers.consumer import AvroConsumer
from confluent_kafka_helpers.producer import AvroProducer

consumer_config = {
    "bootstrap.servers": "localhost:9092",
    "group.id": "example-group",
    "schema.registry.url": "...",
    "topics": ["inventory.article"],
    "headers.propagate": ["x-request-id"],
}

producer_config = {
    "bootstrap.servers": "localhost:9092",
    "schema.registry.url": "...",
    "topics": ["inventory.article", "shop.article"],
}

consumer = AvroConsumer(consumer_config)
producer = AvroProducer(producer_config)

producer.produce(
    topic="inventory.article",
    key="article-123",
    value={
        "class": "CreateArticle",
        "data": { ... },
    },
    headers={"x-request-id": "req-123456"},
)
producer.flush() 

for message in consumer:
    # You do NOT need to pass x-request-id explicitly
    producer.produce(
        topic="shop.article",
        key=message.key,
        value={
            "class": "ShopArticleCreated",
            "data": { ... }
        },
    )
    producer.flush() 