### PR TITLE
fix: remove debug log at import time

### DIFF
--- a/confluent_kafka_helpers/__init__.py
+++ b/confluent_kafka_helpers/__init__.py
@@ -10,16 +10,9 @@ NOTE! Exit functions will not be triggered on SIGKILL, SIGSTOP or os._exit()
 import signal
 import sys
 
-import confluent_kafka
 import structlog
 
 logger = structlog.get_logger(__name__)
-logger.debug(
-    "Using confluent kafka versions",
-    version=confluent_kafka.version(),
-    libversion=confluent_kafka.libversion(),
-)
-
 existing_termination_handler = signal.getsignal(signal.SIGTERM)
 existing_interrupt_handler = signal.getsignal(signal.SIGINT)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="confluent-kafka-helpers",
-    version="1.1.0",
+    version="1.1.1",
     description="Helpers for Confluent's Kafka Python client",
     url="https://github.com/fyndiq/confluent_kafka_helpers",
     author="Fyndiq AB",


### PR DESCRIPTION
## Background

This log creates a log of record at startup time with incorrect formatting. The only way to supress/get correct format is to import this library at run time after setting up the logging config.

## Changes

- Remove debug log from startup