### PR TITLE
fix: use existing logger for consumer/producer

### DIFF
--- a/confluent_kafka_helpers/consumer.py
+++ b/confluent_kafka_helpers/consumer.py
@@ -83,7 +83,7 @@ class AvroConsumer:
         self.propagate_header_keys = self.config.pop("headers.propagate", [])
 
         logger.info("Initializing consumer", config=self.config)
-        self.consumer = ConfluentAvroConsumer(self.config, **kwargs)
+        self.consumer = ConfluentAvroConsumer(self.config, logger=logger, **kwargs)
         self.consumer.subscribe(self.topics)
 
         self._generator = self._message_generator()

--- a/confluent_kafka_helpers/producer.py
+++ b/confluent_kafka_helpers/producer.py
@@ -69,7 +69,7 @@ class AvroProducer(ConfluentAvroProducer):
         logger.info("Initializing producer", config=config)
         atexit.register(self._close)
 
-        super().__init__(config, **kwargs)
+        super().__init__(config, logger=logger, **kwargs)
 
     def _close(self):
         logger.info("Flushing producer")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="confluent-kafka-helpers",
-    version="1.1.1",
+    version="1.1.2",
     description="Helpers for Confluent's Kafka Python client",
     url="https://github.com/fyndiq/confluent_kafka_helpers",
     author="Fyndiq AB",


### PR DESCRIPTION
## Background

Currently, logs from `confluent-kafka-python` are not respecting existing logging config and will produce logs like this:

    %4|1757075950.864|CONFWARN|archiee-nixos#consumer-1| Configuration property `sasl.mechanism` set to `SCRAM-SHA-256` but `security.protocol` is not configured for SASL: recommend setting `security.protocol` to SASL_SSL or SASL_PLAINTEXT 

Instead, we can use existing loggers to get unified formatting, eg using JSON formatter:

    {"event": "CONFWARN [archiee-nixos#consumer-1] Configuration property `sasl.mechanism` set to `SCRAM-SHA-256` but `security.protocol` is not configured for SASL: recommend setting `security.protocol` to SASL_SSL or SASL_PLAINTEXT", "dd.trace_id": null, "dd.span_id": null, "dd.env": "dev", "dd.service": "article-status-projection-service", "dd.version": "undefined", "level": "warning", "logger": "confluent_kafka_helpers.consumer", "timestamp": "2025-09-05T12:50:50.712220Z"}

See https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#kafka-client-configuration for more information.

## Changes

- Use existing loggers when initializing the consumer/producer. 