### PR TITLE
pade-617 graceful shutdown on sigterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ flag is set.
 Long-running handlers can check the flag and bail out early between subtasks:
 
 ```python
-from confluent_kafka_helpers import shutdown_requested
+from confluent_kafka_helpers import is_shutdown_requested
 
 for message in consumer:
     do_step_one(message)
-    if shutdown_requested.is_set():
+    if is_shutdown_requested():
         break
     do_step_two(message)
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ for message in consumer:
 ### Operational notes
 
 - `SIGKILL` cannot be intercepted. Kubernetes will still send it after
-  `terminationGracePeriodSeconds` if the process hasn't exited.
+  `terminationGracePeriodSeconds` if the process hasn't exited. The default value for this in k8s is 30 seconds. If handling a single message can take longer than that the application need to configure a longer `terminationGracePeriodSeconds` in the k8s manifest
 - The flag is process-wide. Tests that exercise it must clear it (see
   `tests/test_signals.py` for the autouse reset fixture pattern).
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,39 @@ Library built on top of [Confluent Kafka
 Python](https://github.com/confluentinc/confluent-kafka-python) adding
 abstractions for consuming and producing messages in a more Pythonic way.
 
+## Graceful shutdown
+
+Importing `confluent_kafka_helpers` installs handlers for `SIGTERM` and `SIGINT`
+that **do not exit the process immediately**. Instead the in-flight message handler always runs to completion before the loop exits.
+
+### Chaining with other signal handlers
+
+If another library (ddtrace, OpenTelemetry SDK, gunicorn, uvicorn, ...) has
+already installed a SIGTERM/SIGINT handler before `confluent_kafka_helpers`
+is imported, the existing handler is captured and **still called** after the
+flag is set.
+
+### Polling the flag from your own code
+
+Long-running handlers can check the flag and bail out early between subtasks:
+
+```python
+from confluent_kafka_helpers import shutdown_requested
+
+for message in consumer:
+    do_step_one(message)
+    if shutdown_requested.is_set():
+        break
+    do_step_two(message)
+```
+
+### Operational notes
+
+- `SIGKILL` cannot be intercepted. Kubernetes will still send it after
+  `terminationGracePeriodSeconds` if the process hasn't exited.
+- The flag is process-wide. Tests that exercise it must clear it (see
+  `tests/test_signals.py` for the autouse reset fixture pattern).
+
 ## OpenTelemetry (OTEL)
 
 ### Test generation of spans

--- a/confluent_kafka_helpers/__init__.py
+++ b/confluent_kafka_helpers/__init__.py
@@ -8,7 +8,7 @@ NOTE! Exit functions will not be triggered on SIGKILL, SIGSTOP or os._exit()
 """
 
 import signal
-import sys
+import threading
 
 import structlog
 
@@ -16,29 +16,29 @@ logger = structlog.get_logger(__name__)
 existing_termination_handler = signal.getsignal(signal.SIGTERM)
 existing_interrupt_handler = signal.getsignal(signal.SIGINT)
 
+shutdown_requested = threading.Event()
+
 
 def termination_handler(signum, frame):
-    logger.debug("Received termination signal", signum=signum)
+    logger.info("Received termination signal", signum=signum)
+    shutdown_requested.set()
     if existing_termination_handler:
         logger.debug(
             "Using existing termination handler",
             name=existing_termination_handler.__qualname__,
         )
         existing_termination_handler(signum, frame)
-    else:
-        sys.exit(0)
 
 
 def interrupt_handler(signum, frame):
-    logger.debug("Received interrupt signal", signum=signum)
+    logger.info("Received interrupt signal", signum=signum)
+    shutdown_requested.set()
     if existing_interrupt_handler:
         logger.debug(
             "Using existing interrupt handler",
             name=existing_interrupt_handler.__qualname__,
         )
         existing_interrupt_handler(signum, frame)
-    else:
-        sys.exit(0)
 
 
 signal.signal(signal.SIGTERM, termination_handler)

--- a/confluent_kafka_helpers/__init__.py
+++ b/confluent_kafka_helpers/__init__.py
@@ -8,6 +8,7 @@ NOTE! Exit functions will not be triggered on SIGKILL, SIGSTOP or os._exit()
 """
 
 import signal
+import sys
 import threading
 
 import structlog
@@ -32,7 +33,10 @@ def clear_shutdown_requested():
 
 
 def termination_handler(signum, frame):
-    logger.debug("Received termination signal", signum=signum)
+    if is_shutdown_requested():
+        logger.debug("Received second termination signal, forcing exit")
+        sys.exit(0)
+    logger.debug("Received termination signal, shutting down gracefully", signum=signum)
     set_shutdown_requested()
     if existing_termination_handler:
         logger.debug(
@@ -43,7 +47,10 @@ def termination_handler(signum, frame):
 
 
 def interrupt_handler(signum, frame):
-    logger.info("Received interrupt signal", signum=signum)
+    if is_shutdown_requested():
+        logger.debug("Received second interrupt signal, forcing exit")
+        sys.exit(0)
+    logger.debug("Received interrupt signal, shutting down gracefully", signum=signum)
     set_shutdown_requested()
     if existing_interrupt_handler:
         logger.debug(

--- a/confluent_kafka_helpers/__init__.py
+++ b/confluent_kafka_helpers/__init__.py
@@ -19,9 +19,21 @@ existing_interrupt_handler = signal.getsignal(signal.SIGINT)
 shutdown_requested = threading.Event()
 
 
-def termination_handler(signum, frame):
-    logger.info("Received termination signal", signum=signum)
+def is_shutdown_requested() -> bool:
+    return shutdown_requested.is_set()
+
+
+def set_shutdown_requested():
     shutdown_requested.set()
+
+
+def clear_shutdown_requested():
+    shutdown_requested.clear()
+
+
+def termination_handler(signum, frame):
+    logger.debug("Received termination signal", signum=signum)
+    set_shutdown_requested()
     if existing_termination_handler:
         logger.debug(
             "Using existing termination handler",
@@ -32,7 +44,7 @@ def termination_handler(signum, frame):
 
 def interrupt_handler(signum, frame):
     logger.info("Received interrupt signal", signum=signum)
-    shutdown_requested.set()
+    set_shutdown_requested()
     if existing_interrupt_handler:
         logger.debug(
             "Using existing interrupt handler",

--- a/confluent_kafka_helpers/consumer.py
+++ b/confluent_kafka_helpers/consumer.py
@@ -7,7 +7,7 @@ from confluent_kafka import Consumer, KafkaError, KafkaException
 from confluent_kafka.avro import AvroConsumer as ConfluentAvroConsumer
 from opentelemetry.trace import SpanKind
 
-from confluent_kafka_helpers import shutdown_requested
+from confluent_kafka_helpers import is_shutdown_requested
 from confluent_kafka_helpers.callbacks import default_error_cb, default_stats_cb, get_callback
 from confluent_kafka_helpers.context import clear_propagated_headers, set_propagated_headers
 from confluent_kafka_helpers.exceptions import EndOfPartition, KafkaTransportError
@@ -138,7 +138,7 @@ class AvroConsumer:
         self._generator.close()
 
     def _message_generator(self):
-        while not shutdown_requested.is_set():
+        while not is_shutdown_requested():
             message = self._get_message()
             if message is None:
                 if self.non_blocking:

--- a/confluent_kafka_helpers/consumer.py
+++ b/confluent_kafka_helpers/consumer.py
@@ -7,6 +7,7 @@ from confluent_kafka import Consumer, KafkaError, KafkaException
 from confluent_kafka.avro import AvroConsumer as ConfluentAvroConsumer
 from opentelemetry.trace import SpanKind
 
+from confluent_kafka_helpers import shutdown_requested
 from confluent_kafka_helpers.callbacks import default_error_cb, default_stats_cb, get_callback
 from confluent_kafka_helpers.context import clear_propagated_headers, set_propagated_headers
 from confluent_kafka_helpers.exceptions import EndOfPartition, KafkaTransportError
@@ -137,7 +138,7 @@ class AvroConsumer:
         self._generator.close()
 
     def _message_generator(self):
-        while True:
+        while not shutdown_requested.is_set():
             message = self._get_message()
             if message is None:
                 if self.non_blocking:
@@ -198,6 +199,7 @@ class AvroConsumer:
                 yield message
 
                 clear_propagated_headers()
+        logger.info("Shutdown requested, exiting consumer loop")
 
     def _get_topics(self, config):
         topics = config.pop("topics", None)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="confluent-kafka-helpers",
-    version="1.2.0",
+    version="1.3.0",
     description="Helpers for Confluent's Kafka Python client",
     url="https://github.com/fyndiq/confluent_kafka_helpers",
     author="Fyndiq AB",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from confluent_kafka.avro import AvroConsumer as ConfluentAvroConsumer
 
+import confluent_kafka_helpers
 from confluent_kafka_helpers import consumer
 
 from tests import config
@@ -79,3 +80,11 @@ def avro_schema_registry():
             patch("confluent_kafka_helpers.loader.AvroSchemaRegistry", schema_registry)
         )
         yield schema_registry
+
+
+@pytest.fixture(autouse=True)
+def _reset_shutdown_state():
+    """Clear the module-level shutdown flag before and after every test."""
+    confluent_kafka_helpers.clear_shutdown_requested()
+    yield
+    confluent_kafka_helpers.clear_shutdown_requested()

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -293,7 +293,7 @@ class TestGracefulShutdown:
             if i >= 5:
                 pytest.fail(
                     "Consumer kept yielding messages after shutdown_requested "
-                    "was set — drain-on-shutdown is not implemented."
+                    "was set — stop-after-current-message is not implemented."
                 )
 
         assert len(processed) == 1
@@ -312,7 +312,7 @@ class TestGracefulShutdown:
                 if i >= 5:
                     pytest.fail(
                         "Consumer kept yielding messages after shutdown_requested "
-                        "was set — drain-on-shutdown is not implemented."
+                        "was set — stop-after-current-message is not implemented."
                     )
 
         close_spy.assert_called_once()

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -275,7 +275,7 @@ class TestGracefulShutdown:
         first = next(iterator)
         assert first.value == b"foobar"
 
-        confluent_kafka_helpers.shutdown_requested.set()
+        confluent_kafka_helpers.set_shutdown_requested()
 
         with pytest.raises(StopIteration):
             next(iterator)
@@ -289,7 +289,7 @@ class TestGracefulShutdown:
         processed = []
         for i, message in enumerate(consumer):
             processed.append(message)
-            confluent_kafka_helpers.shutdown_requested.set()
+            confluent_kafka_helpers.set_shutdown_requested()
             if i >= 5:
                 pytest.fail(
                     "Consumer kept yielding messages after shutdown_requested "
@@ -308,7 +308,7 @@ class TestGracefulShutdown:
 
         with consumer as c:
             for i, _ in enumerate(c):
-                confluent_kafka_helpers.shutdown_requested.set()
+                confluent_kafka_helpers.set_shutdown_requested()
                 if i >= 5:
                     pytest.fail(
                         "Consumer kept yielding messages after shutdown_requested "
@@ -323,7 +323,7 @@ class TestGracefulShutdown:
         consumer = avro_consumer()
         self._patch_poll_to_be_inexhaustible(consumer, confluent_message)
 
-        confluent_kafka_helpers.shutdown_requested.set()
+        confluent_kafka_helpers.set_shutdown_requested()
 
         with pytest.raises(StopIteration):
             next(iter(consumer))

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -257,9 +257,7 @@ def _reset_shutdown_state_for_consumer_tests():
 class TestGracefulShutdown:
     @staticmethod
     def _patch_poll_to_be_inexhaustible(consumer, confluent_message):
-        """Default fixtures use side_effect=[msg, StopIteration] which makes
-        the second poll exhaust and produce a RuntimeError (PEP 479). For
-        these tests we need poll to return messages forever so that the
+        """Forthese tests we need poll to return messages forever so that the
         ONLY thing that stops iteration is the shutdown flag."""
         message = confluent_message()
         consumer.consumer.poll = MagicMock(side_effect=lambda timeout: message)

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -5,12 +5,12 @@ from confluent_kafka import KafkaError as ConfluentKafkaError
 from confluent_kafka import KafkaException
 from opentelemetry.trace import SpanKind
 
+import confluent_kafka_helpers
 from confluent_kafka_helpers.consumer import (
     default_error_handler,
     get_message,
     is_kafka_transient_error,
 )
-import confluent_kafka_helpers
 from confluent_kafka_helpers.exceptions import EndOfPartition, KafkaTransportError
 
 from tests.kafka import KafkaError, KafkaMessage
@@ -241,6 +241,8 @@ class TestAvroConsumerCommit:
             consumer.commit()
 
         assert consumer.consumer.commit.call_count == 1
+
+
 @pytest.fixture(autouse=True)
 def _reset_shutdown_state_for_consumer_tests():
     """Tests in TestGracefulShutdown set the module-level flag. Clear it

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, Mock, call, patch
+from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
 from confluent_kafka import KafkaError as ConfluentKafkaError
@@ -10,6 +10,7 @@ from confluent_kafka_helpers.consumer import (
     get_message,
     is_kafka_transient_error,
 )
+import confluent_kafka_helpers
 from confluent_kafka_helpers.exceptions import EndOfPartition, KafkaTransportError
 
 from tests.kafka import KafkaError, KafkaMessage
@@ -240,3 +241,89 @@ class TestAvroConsumerCommit:
             consumer.commit()
 
         assert consumer.consumer.commit.call_count == 1
+@pytest.fixture(autouse=True)
+def _reset_shutdown_state_for_consumer_tests():
+    """Tests in TestGracefulShutdown set the module-level flag. Clear it
+    before/after every test so unrelated tests don't observe a stale flag."""
+    flag = getattr(confluent_kafka_helpers, "shutdown_requested", None)
+    if flag is not None:
+        flag.clear()
+    yield
+    flag = getattr(confluent_kafka_helpers, "shutdown_requested", None)
+    if flag is not None:
+        flag.clear()
+
+
+class TestGracefulShutdown:
+    @staticmethod
+    def _patch_poll_to_be_inexhaustible(consumer, confluent_message):
+        """Default fixtures use side_effect=[msg, StopIteration] which makes
+        the second poll exhaust and produce a RuntimeError (PEP 479). For
+        these tests we need poll to return messages forever so that the
+        ONLY thing that stops iteration is the shutdown flag."""
+        message = confluent_message()
+        consumer.consumer.poll = MagicMock(side_effect=lambda timeout: message)
+        consumer._generator = consumer._message_generator()
+
+    def test_generator_stops_when_shutdown_requested_after_first_message(
+        self, avro_consumer, confluent_message
+    ):
+        consumer = avro_consumer()
+        self._patch_poll_to_be_inexhaustible(consumer, confluent_message)
+
+        iterator = iter(consumer)
+        first = next(iterator)
+        assert first.value == b"foobar"
+
+        confluent_kafka_helpers.shutdown_requested.set()
+
+        with pytest.raises(StopIteration):
+            next(iterator)
+
+    def test_for_loop_exits_after_processing_in_flight_message(
+        self, avro_consumer, confluent_message
+    ):
+        consumer = avro_consumer()
+        self._patch_poll_to_be_inexhaustible(consumer, confluent_message)
+
+        processed = []
+        for i, message in enumerate(consumer):
+            processed.append(message)
+            confluent_kafka_helpers.shutdown_requested.set()
+            if i >= 5:
+                pytest.fail(
+                    "Consumer kept yielding messages after shutdown_requested "
+                    "was set — drain-on-shutdown is not implemented."
+                )
+
+        assert len(processed) == 1
+
+    def test_consumer_close_runs_after_graceful_shutdown(
+        self, avro_consumer, confluent_message, mocker
+    ):
+        consumer = avro_consumer()
+        self._patch_poll_to_be_inexhaustible(consumer, confluent_message)
+
+        close_spy = mocker.spy(consumer.consumer, "close")
+
+        with consumer as c:
+            for i, _ in enumerate(c):
+                confluent_kafka_helpers.shutdown_requested.set()
+                if i >= 5:
+                    pytest.fail(
+                        "Consumer kept yielding messages after shutdown_requested "
+                        "was set — drain-on-shutdown is not implemented."
+                    )
+
+        close_spy.assert_called_once()
+
+    def test_no_messages_yielded_if_shutdown_requested_before_iteration(
+        self, avro_consumer, confluent_message
+    ):
+        consumer = avro_consumer()
+        self._patch_poll_to_be_inexhaustible(consumer, confluent_message)
+
+        confluent_kafka_helpers.shutdown_requested.set()
+
+        with pytest.raises(StopIteration):
+            next(iter(consumer))

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -106,6 +106,34 @@ class TestEndToEndSignalDelivery:
         assert confluent_kafka_helpers.is_shutdown_requested()
 
 
+class TestSecondSignalForcesExit:
+    """A second SIGTERM or SIGINT while shutdown is already requested must
+    force-exit via sys.exit(0). This is the operator escape hatch for hung
+    handlers or non-consumer processes."""
+
+    def test_second_sigterm_raises_system_exit(self, isolated_handlers):
+        confluent_kafka_helpers.set_shutdown_requested()
+        with pytest.raises(SystemExit) as exc_info:
+            confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
+        assert exc_info.value.code == 0
+
+    def test_second_sigint_raises_system_exit(self, isolated_handlers):
+        confluent_kafka_helpers.set_shutdown_requested()
+        with pytest.raises(SystemExit) as exc_info:
+            confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
+        assert exc_info.value.code == 0
+
+    def test_second_signal_does_not_call_chained_handler(self, monkeypatch):
+        existing = MagicMock()
+        existing.__qualname__ = "existing_sigterm"
+        monkeypatch.setattr("confluent_kafka_helpers.existing_termination_handler", existing)
+
+        confluent_kafka_helpers.set_shutdown_requested()
+        with pytest.raises(SystemExit):
+            confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
+        existing.assert_not_called()
+
+
 class TestChainedHandlers:
     """Regression tests for the chained-handler case.
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,23 +1,11 @@
 """
 Contract tests for graceful shutdown on SIGTERM / SIGINT.
+The desired behaviour is "stop-after-current-message":
 
-Motivation (PADE-617): when Kubernetes scales down a pod, the kubelet sends
-SIGTERM to PID 1 in each container. The current handler in
-`confluent_kafka_helpers/__init__.py` reacts by calling `sys.exit(0)`, which
-raises `SystemExit` at the next bytecode boundary on the main thread. If the
-signal arrives in the middle of a Kafka message handler (between a DB commit
-and an external HTTP call, say), the handler is interrupted mid-flight and the
-application's `except Exception:` cleanup wrapper does not catch it
-(`SystemExit` inherits from `BaseException`, not `Exception`).
-
-The desired behaviour is "drain-on-shutdown":
-
-* First SIGTERM / SIGINT must NOT raise — it just records that shutdown was
+* SIGTERM / SIGINT must NOT raise — it just records that shutdown was
   requested. In-flight Python code (the user's message handler) runs to
   completion.
 * The consumer loop checks the flag between messages and exits cleanly.
-* A second signal is treated as an operator escape hatch: "I really mean it,
-  exit now" — that one is allowed to raise `SystemExit`.
 
 The flag itself is exposed as `confluent_kafka_helpers.shutdown_requested` so
 that user code (and the consumer loop) can poll it.
@@ -25,6 +13,7 @@ that user code (and the consumer loop) can poll it.
 
 import signal
 import threading
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -33,8 +22,7 @@ import confluent_kafka_helpers
 
 @pytest.fixture(autouse=True)
 def _reset_shutdown_state():
-    """Clear the module-level shutdown flag before and after every test.
-    Without this, a test that sets the flag leaks state into the next test."""
+    """Clear the module-level shutdown flag before and after every test."""
     flag = getattr(confluent_kafka_helpers, "shutdown_requested", None)
     if flag is not None:
         flag.clear()
@@ -61,9 +49,7 @@ class TestShutdownRequestedFlag:
             "confluent_kafka_helpers must expose a public `shutdown_requested` "
             "flag so the consume loop can check it between messages."
         )
-        assert isinstance(
-            confluent_kafka_helpers.shutdown_requested, threading.Event
-        ), (
+        assert isinstance(confluent_kafka_helpers.shutdown_requested, threading.Event), (
             "`shutdown_requested` should be a `threading.Event` so it is "
             "thread-safe and has the standard is_set/set/clear API."
         )
@@ -80,13 +66,6 @@ class TestTerminationHandler:
         confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
         assert confluent_kafka_helpers.shutdown_requested.is_set()
 
-    def test_second_signal_raises_systemexit(self, isolated_handlers):
-        """Operator escape hatch: a second SIGTERM means 'I really mean it'.
-        The handler is allowed to short-circuit and exit immediately."""
-        confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
-        with pytest.raises(SystemExit):
-            confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
-
 
 class TestInterruptHandler:
     def test_first_signal_does_not_raise(self, isolated_handlers):
@@ -95,11 +74,6 @@ class TestInterruptHandler:
     def test_first_signal_sets_shutdown_flag(self, isolated_handlers):
         confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
         assert confluent_kafka_helpers.shutdown_requested.is_set()
-
-    def test_second_signal_raises_systemexit(self, isolated_handlers):
-        confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
-        with pytest.raises(SystemExit):
-            confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
 
 
 class TestSignalsShareTheSameFlag:
@@ -110,3 +84,61 @@ class TestSignalsShareTheSameFlag:
     def test_sigint_sets_the_same_flag_sigterm_does(self, isolated_handlers):
         confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
         assert confluent_kafka_helpers.shutdown_requested.is_set()
+
+
+class TestChainedHandlers:
+    """Regression tests for the chained-handler case.
+
+    When this library is imported AFTER another framework (ddtrace, OTel SDK,
+    gunicorn, uvicorn, ...) has already installed a SIGTERM/SIGINT handler,
+    that handler is captured in `existing_*_handler` at import time and the
+    library's handler chains to it.
+
+    Both the chained handler AND the `shutdown_requested` flag must run.
+    If we only chain and skip the flag, the consumer loop never sees the
+    shutdown request and graceful shutdown silently breaks in any service
+    that pulls in another signal-handling library — which is the common case
+    in production.
+    """
+
+    @staticmethod
+    def _make_handler_mock(qualname):
+        # `__qualname__` is read for the debug log line; give it a real string
+        # so structlog doesn't serialise a nested Mock.
+        handler = MagicMock()
+        handler.__qualname__ = qualname
+        return handler
+
+    def test_termination_calls_existing_handler_and_sets_flag(self, monkeypatch):
+        existing = self._make_handler_mock("existing_sigterm")
+        monkeypatch.setattr("confluent_kafka_helpers.existing_termination_handler", existing)
+
+        confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
+
+        existing.assert_called_once_with(signal.SIGTERM, None)
+        assert confluent_kafka_helpers.shutdown_requested.is_set()
+
+    def test_interrupt_calls_existing_handler_and_sets_flag(self, monkeypatch):
+        existing = self._make_handler_mock("existing_sigint")
+        monkeypatch.setattr("confluent_kafka_helpers.existing_interrupt_handler", existing)
+
+        confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
+
+        existing.assert_called_once_with(signal.SIGINT, None)
+        assert confluent_kafka_helpers.shutdown_requested.is_set()
+
+    def test_flag_is_set_before_existing_handler_runs(self, monkeypatch):
+        """Order matters: if the chained handler raises (e.g. an aggressive
+        framework calls sys.exit), we still want the consumer loop to know
+        shutdown was requested. So the flag must be set BEFORE chaining."""
+        observed = {}
+
+        def existing(signum, frame):
+            observed["flag_was_set"] = confluent_kafka_helpers.shutdown_requested.is_set()
+
+        existing.__qualname__ = "existing_sigterm"
+        monkeypatch.setattr("confluent_kafka_helpers.existing_termination_handler", existing)
+
+        confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
+
+        assert observed["flag_was_set"] is True

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -20,18 +20,6 @@ import pytest
 import confluent_kafka_helpers
 
 
-@pytest.fixture(autouse=True)
-def _reset_shutdown_state():
-    """Clear the module-level shutdown flag before and after every test."""
-    flag = getattr(confluent_kafka_helpers, "shutdown_requested", None)
-    if flag is not None:
-        flag.clear()
-    yield
-    flag = getattr(confluent_kafka_helpers, "shutdown_requested", None)
-    if flag is not None:
-        flag.clear()
-
-
 @pytest.fixture
 def isolated_handlers(monkeypatch):
     """Strip pre-existing SIGTERM/SIGINT handlers captured at module import
@@ -55,7 +43,7 @@ class TestShutdownRequestedFlag:
         )
 
     def test_shutdown_requested_is_initially_unset(self):
-        assert not confluent_kafka_helpers.shutdown_requested.is_set()
+        assert not confluent_kafka_helpers.is_shutdown_requested()
 
 
 class TestTerminationHandler:
@@ -64,7 +52,7 @@ class TestTerminationHandler:
 
     def test_first_signal_sets_shutdown_flag(self, isolated_handlers):
         confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
-        assert confluent_kafka_helpers.shutdown_requested.is_set()
+        assert confluent_kafka_helpers.is_shutdown_requested()
 
 
 class TestInterruptHandler:
@@ -73,17 +61,17 @@ class TestInterruptHandler:
 
     def test_first_signal_sets_shutdown_flag(self, isolated_handlers):
         confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
-        assert confluent_kafka_helpers.shutdown_requested.is_set()
+        assert confluent_kafka_helpers.is_shutdown_requested()
 
 
 class TestSignalsShareTheSameFlag:
     def test_sigterm_sets_the_same_flag_sigint_does(self, isolated_handlers):
         confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
-        assert confluent_kafka_helpers.shutdown_requested.is_set()
+        assert confluent_kafka_helpers.is_shutdown_requested()
 
     def test_sigint_sets_the_same_flag_sigterm_does(self, isolated_handlers):
         confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
-        assert confluent_kafka_helpers.shutdown_requested.is_set()
+        assert confluent_kafka_helpers.is_shutdown_requested()
 
 
 class TestChainedHandlers:
@@ -116,7 +104,7 @@ class TestChainedHandlers:
         confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
 
         existing.assert_called_once_with(signal.SIGTERM, None)
-        assert confluent_kafka_helpers.shutdown_requested.is_set()
+        assert confluent_kafka_helpers.is_shutdown_requested()
 
     def test_interrupt_calls_existing_handler_and_sets_flag(self, monkeypatch):
         existing = self._make_handler_mock("existing_sigint")
@@ -125,7 +113,7 @@ class TestChainedHandlers:
         confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
 
         existing.assert_called_once_with(signal.SIGINT, None)
-        assert confluent_kafka_helpers.shutdown_requested.is_set()
+        assert confluent_kafka_helpers.is_shutdown_requested()
 
     def test_flag_is_set_before_existing_handler_runs(self, monkeypatch):
         """Order matters: if the chained handler raises (e.g. an aggressive
@@ -134,7 +122,7 @@ class TestChainedHandlers:
         observed = {}
 
         def existing(signum, frame):
-            observed["flag_was_set"] = confluent_kafka_helpers.shutdown_requested.is_set()
+            observed["flag_was_set"] = confluent_kafka_helpers.is_shutdown_requested()
 
         existing.__qualname__ = "existing_sigterm"
         monkeypatch.setattr("confluent_kafka_helpers.existing_termination_handler", existing)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -74,6 +74,38 @@ class TestSignalsShareTheSameFlag:
         assert confluent_kafka_helpers.is_shutdown_requested()
 
 
+class TestEndToEndSignalDelivery:
+    """End-to-end tests that go through the OS signal machinery rather than
+    invoking the handler functions directly.
+
+    `signal.raise_signal(signum)` sends the signal to the current process;
+    Python then invokes the registered handler between bytecodes. This catches
+    regressions the direct-call tests miss:
+
+    * the import-time `signal.signal(...)` registration silently going away
+      (without registration SIGTERM would terminate the test process and
+      SIGINT would raise `KeyboardInterrupt`, surfaced as a test failure),
+    * signal-safety issues that only show up when Python — not the test —
+      drives handler invocation.
+    """
+
+    def test_termination_handler_is_registered_at_import_time(self):
+        assert signal.getsignal(signal.SIGTERM) is confluent_kafka_helpers.termination_handler
+
+    def test_interrupt_handler_is_registered_at_import_time(self):
+        assert signal.getsignal(signal.SIGINT) is confluent_kafka_helpers.interrupt_handler
+
+    def test_real_sigterm_delivery_sets_shutdown_flag(self, isolated_handlers):
+        assert not confluent_kafka_helpers.is_shutdown_requested()
+        signal.raise_signal(signal.SIGTERM)
+        assert confluent_kafka_helpers.is_shutdown_requested()
+
+    def test_real_sigint_delivery_sets_shutdown_flag(self, isolated_handlers):
+        assert not confluent_kafka_helpers.is_shutdown_requested()
+        signal.raise_signal(signal.SIGINT)
+        assert confluent_kafka_helpers.is_shutdown_requested()
+
+
 class TestChainedHandlers:
     """Regression tests for the chained-handler case.
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,112 @@
+"""
+Contract tests for graceful shutdown on SIGTERM / SIGINT.
+
+Motivation (PADE-617): when Kubernetes scales down a pod, the kubelet sends
+SIGTERM to PID 1 in each container. The current handler in
+`confluent_kafka_helpers/__init__.py` reacts by calling `sys.exit(0)`, which
+raises `SystemExit` at the next bytecode boundary on the main thread. If the
+signal arrives in the middle of a Kafka message handler (between a DB commit
+and an external HTTP call, say), the handler is interrupted mid-flight and the
+application's `except Exception:` cleanup wrapper does not catch it
+(`SystemExit` inherits from `BaseException`, not `Exception`).
+
+The desired behaviour is "drain-on-shutdown":
+
+* First SIGTERM / SIGINT must NOT raise — it just records that shutdown was
+  requested. In-flight Python code (the user's message handler) runs to
+  completion.
+* The consumer loop checks the flag between messages and exits cleanly.
+* A second signal is treated as an operator escape hatch: "I really mean it,
+  exit now" — that one is allowed to raise `SystemExit`.
+
+The flag itself is exposed as `confluent_kafka_helpers.shutdown_requested` so
+that user code (and the consumer loop) can poll it.
+"""
+
+import signal
+import threading
+
+import pytest
+
+import confluent_kafka_helpers
+
+
+@pytest.fixture(autouse=True)
+def _reset_shutdown_state():
+    """Clear the module-level shutdown flag before and after every test.
+    Without this, a test that sets the flag leaks state into the next test."""
+    flag = getattr(confluent_kafka_helpers, "shutdown_requested", None)
+    if flag is not None:
+        flag.clear()
+    yield
+    flag = getattr(confluent_kafka_helpers, "shutdown_requested", None)
+    if flag is not None:
+        flag.clear()
+
+
+@pytest.fixture
+def isolated_handlers(monkeypatch):
+    """Strip pre-existing SIGTERM/SIGINT handlers captured at module import
+    time (e.g. pytest's own SIGINT handler). Without this, calls to the
+    library handlers chain into pytest internals and the tests become
+    non-deterministic depending on import order."""
+    for name in ("existing_termination_handler", "existing_interrupt_handler"):
+        if hasattr(confluent_kafka_helpers, name):
+            monkeypatch.setattr(f"confluent_kafka_helpers.{name}", None)
+
+
+class TestShutdownRequestedFlag:
+    def test_module_exposes_shutdown_requested_event(self):
+        assert hasattr(confluent_kafka_helpers, "shutdown_requested"), (
+            "confluent_kafka_helpers must expose a public `shutdown_requested` "
+            "flag so the consume loop can check it between messages."
+        )
+        assert isinstance(
+            confluent_kafka_helpers.shutdown_requested, threading.Event
+        ), (
+            "`shutdown_requested` should be a `threading.Event` so it is "
+            "thread-safe and has the standard is_set/set/clear API."
+        )
+
+    def test_shutdown_requested_is_initially_unset(self):
+        assert not confluent_kafka_helpers.shutdown_requested.is_set()
+
+
+class TestTerminationHandler:
+    def test_first_signal_does_not_raise(self, isolated_handlers):
+        confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
+
+    def test_first_signal_sets_shutdown_flag(self, isolated_handlers):
+        confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
+        assert confluent_kafka_helpers.shutdown_requested.is_set()
+
+    def test_second_signal_raises_systemexit(self, isolated_handlers):
+        """Operator escape hatch: a second SIGTERM means 'I really mean it'.
+        The handler is allowed to short-circuit and exit immediately."""
+        confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
+        with pytest.raises(SystemExit):
+            confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
+
+
+class TestInterruptHandler:
+    def test_first_signal_does_not_raise(self, isolated_handlers):
+        confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
+
+    def test_first_signal_sets_shutdown_flag(self, isolated_handlers):
+        confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
+        assert confluent_kafka_helpers.shutdown_requested.is_set()
+
+    def test_second_signal_raises_systemexit(self, isolated_handlers):
+        confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
+        with pytest.raises(SystemExit):
+            confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
+
+
+class TestSignalsShareTheSameFlag:
+    def test_sigterm_sets_the_same_flag_sigint_does(self, isolated_handlers):
+        confluent_kafka_helpers.termination_handler(signal.SIGTERM, None)
+        assert confluent_kafka_helpers.shutdown_requested.is_set()
+
+    def test_sigint_sets_the_same_flag_sigterm_does(self, isolated_handlers):
+        confluent_kafka_helpers.interrupt_handler(signal.SIGINT, None)
+        assert confluent_kafka_helpers.shutdown_requested.is_set()


### PR DESCRIPTION
# Background
In [this ticket](https://linear.app/cdon-ab/issue/PADE-617/qliro-integration-orders-stuck-after-pod-sigkill-processed-events) we discovered a problem (most likely) because an event was halfway handled in a consumer, then the consumer pod was killed, perhaps scaled down by k8s. This left the service in an inconsistent state. This error[ has now been fixed](https://github.com/fyndiq/qliro-integration-service/pull/457), but despite this it would be good to support graceful shutdown for all consumers using this library.

# Changes
When receiving SIGTERM or SIGINT:
- **Don't** shut down immediately
- Instead wait for the current message to be fully handled and then shut down