### PR TITLE
Retry commit on transient kafka issues

### DIFF
--- a/confluent_kafka_helpers/consumer.py
+++ b/confluent_kafka_helpers/consumer.py
@@ -49,7 +49,12 @@ def default_error_handler(kafka_error):
         raise KafkaException(kafka_error)
 
 
-def is_kafka_transient_error(error: KafkaError):
+def is_kafka_transient_error(exc: KafkaException):
+    if not exc.args:
+        return False
+    error = exc.args[0]
+    if not isinstance(error, KafkaError):
+        return False
     return error.code() in {KafkaError.REQUEST_TIMED_OUT, KafkaError.BROKER_NOT_AVAILABLE}
 
 
@@ -207,7 +212,7 @@ class AvroConsumer:
     def is_auto_commit(self):
         return self.config.get("enable.auto.commit", True)
 
-    @retry_exception(exceptions={KafkaError}, condition=is_kafka_transient_error)
+    @retry_exception(exceptions={KafkaException}, condition=is_kafka_transient_error)
     def commit(self, *args, **kwargs):
         with tracer.start_span(name="kafka.commit", kind=SpanKind.CONSUMER):
             self.consumer.commit(*args, **kwargs)

--- a/confluent_kafka_helpers/consumer.py
+++ b/confluent_kafka_helpers/consumer.py
@@ -49,6 +49,10 @@ def default_error_handler(kafka_error):
         raise KafkaException(kafka_error)
 
 
+def is_kafka_transient_error(error: KafkaError):
+    return error.code() in {KafkaError.REQUEST_TIMED_OUT, KafkaError.BROKER_NOT_AVAILABLE}
+
+
 class AvroConsumer:
     DEFAULT_CONFIG = {
         "client.id": socket.gethostname(),
@@ -203,6 +207,7 @@ class AvroConsumer:
     def is_auto_commit(self):
         return self.config.get("enable.auto.commit", True)
 
+    @retry_exception(exceptions={KafkaError}, condition=is_kafka_transient_error)
     def commit(self, *args, **kwargs):
         with tracer.start_span(name="kafka.commit", kind=SpanKind.CONSUMER):
             self.consumer.commit(*args, **kwargs)

--- a/confluent_kafka_helpers/utils.py
+++ b/confluent_kafka_helpers/utils.py
@@ -1,11 +1,11 @@
 from functools import wraps
-
+from typing import Callable
 import structlog
 
 logger = structlog.get_logger(__name__)
 
 
-def retry_exception(exceptions, retries=3):
+def retry_exception(exceptions, retries=3, condition: Callable = lambda exc: True):
     def decorator(func):
         @wraps(func)
         def wrapped(*args, **kwargs):
@@ -14,7 +14,7 @@ def retry_exception(exceptions, retries=3):
                 try:
                     return func(*args, **kwargs)
                 except Exception as exc:
-                    if any([isinstance(exc, e) for e in exceptions]):
+                    if any([isinstance(exc, e) for e in exceptions]) and condition(exc):
                         logger.warning("Retrying exception", exc=exc, retry=retry_count)
                         retry_count += 1
                         if retry_count < retries:

--- a/confluent_kafka_helpers/utils.py
+++ b/confluent_kafka_helpers/utils.py
@@ -1,5 +1,6 @@
 from functools import wraps
 from typing import Callable
+
 import structlog
 
 logger = structlog.get_logger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="confluent-kafka-helpers",
-    version="1.1.2",
+    version="1.2.0",
     description="Helpers for Confluent's Kafka Python client",
     url="https://github.com/fyndiq/confluent_kafka_helpers",
     author="Fyndiq AB",

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -5,7 +5,11 @@ from confluent_kafka import KafkaError as ConfluentKafkaError
 from confluent_kafka import KafkaException
 from opentelemetry.trace import SpanKind
 
-from confluent_kafka_helpers.consumer import default_error_handler, get_message
+from confluent_kafka_helpers.consumer import (
+    default_error_handler,
+    get_message,
+    is_kafka_transient_error,
+)
 from confluent_kafka_helpers.exceptions import EndOfPartition, KafkaTransportError
 
 from tests.kafka import KafkaError, KafkaMessage
@@ -143,3 +147,96 @@ class TestErrorHandler:
         error = KafkaError(_code=code)
         with pytest.raises(KafkaException):
             default_error_handler(error)
+
+
+class TestIsKafkaTransientError:
+    @pytest.mark.parametrize(
+        "code",
+        [
+            ConfluentKafkaError.REQUEST_TIMED_OUT,
+            ConfluentKafkaError.BROKER_NOT_AVAILABLE,
+        ],
+    )
+    def test_returns_true_for_transient_codes(self, code):
+        exc = KafkaException(ConfluentKafkaError(code))
+        assert is_kafka_transient_error(exc) is True
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            ConfluentKafkaError._ALL_BROKERS_DOWN,
+            ConfluentKafkaError._TIMED_OUT,
+            ConfluentKafkaError._TRANSPORT,
+            ConfluentKafkaError.OFFSET_OUT_OF_RANGE,
+            ConfluentKafkaError.UNKNOWN_TOPIC_OR_PART,
+        ],
+    )
+    def test_returns_false_for_non_transient_codes(self, code):
+        exc = KafkaException(ConfluentKafkaError(code))
+        assert is_kafka_transient_error(exc) is False
+
+    def test_returns_false_for_exception_without_args(self):
+        exc = KafkaException()
+        assert is_kafka_transient_error(exc) is False
+
+
+class TestAvroConsumerCommit:
+    def test_successful_commit_does_not_retry(self, avro_consumer):
+        consumer = avro_consumer()
+        consumer.consumer.commit = Mock()
+
+        consumer.commit()
+
+        assert consumer.consumer.commit.call_count == 1
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            ConfluentKafkaError.REQUEST_TIMED_OUT,
+            ConfluentKafkaError.BROKER_NOT_AVAILABLE,
+        ],
+    )
+    def test_retries_on_transient_errors(self, code, avro_consumer):
+        consumer = avro_consumer()
+        transient_error = KafkaException(ConfluentKafkaError(code))
+        consumer.consumer.commit = Mock(side_effect=[transient_error, transient_error, None])
+
+        consumer.commit()
+
+        assert consumer.consumer.commit.call_count == 3
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            ConfluentKafkaError.REQUEST_TIMED_OUT,
+            ConfluentKafkaError.BROKER_NOT_AVAILABLE,
+        ],
+    )
+    def test_reraises_after_max_retries_on_transient_error(self, code, avro_consumer):
+        consumer = avro_consumer()
+        transient_error = KafkaException(ConfluentKafkaError(code))
+        consumer.consumer.commit = Mock(side_effect=transient_error)
+
+        with pytest.raises(KafkaException) as exc_info:
+            consumer.commit()
+
+        assert exc_info.value.args[0].code() == code
+        assert consumer.consumer.commit.call_count == 3
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            ConfluentKafkaError._ALL_BROKERS_DOWN,
+            ConfluentKafkaError.OFFSET_OUT_OF_RANGE,
+            ConfluentKafkaError.UNKNOWN_TOPIC_OR_PART,
+        ],
+    )
+    def test_does_not_retry_on_non_transient_errors(self, code, avro_consumer):
+        consumer = avro_consumer()
+        non_transient = KafkaException(ConfluentKafkaError(code))
+        consumer.consumer.commit = Mock(side_effect=non_transient)
+
+        with pytest.raises(KafkaException):
+            consumer.commit()
+
+        assert consumer.consumer.commit.call_count == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,3 +25,54 @@ class TestRetryException:
         value = foo(mock)
         assert mock.call_count == 2
         assert value == 2
+
+    def test_condition_true_retries(self):
+        @retry_exception([ValueError], condition=lambda exc: True)
+        def foo(mock):
+            raise mock()
+
+        mock = Mock(side_effect=ValueError)
+        with pytest.raises(ValueError):
+            foo(mock)
+        assert mock.call_count == 3
+
+    def test_condition_false_does_not_retry(self):
+        @retry_exception([ValueError], condition=lambda exc: False)
+        def foo(mock):
+            raise mock()
+
+        mock = Mock(side_effect=ValueError)
+        with pytest.raises(ValueError):
+            foo(mock)
+        assert mock.call_count == 1
+
+    def test_condition_can_filter_by_exception_attribute(self):
+        @retry_exception([ValueError], condition=lambda exc: "retry" in str(exc))
+        def foo(mock):
+            raise mock()
+
+        retry_then_fatal = Mock(side_effect=[ValueError("retry me"), ValueError("fatal")])
+        with pytest.raises(ValueError, match="fatal"):
+            foo(retry_then_fatal)
+        assert retry_then_fatal.call_count == 2
+
+    def test_default_condition_retries_all(self):
+        @retry_exception([ValueError])
+        def foo(mock):
+            raise mock()
+
+        mock = Mock(side_effect=ValueError)
+        with pytest.raises(ValueError):
+            foo(mock)
+        assert mock.call_count == 3
+
+    def test_non_matching_exception_does_not_invoke_condition(self):
+        condition = Mock(return_value=True)
+
+        @retry_exception([ValueError], condition=condition)
+        def foo():
+            raise TypeError("not in list")
+
+        with pytest.raises(TypeError):
+            foo()
+        condition.assert_not_called()


### PR DESCRIPTION
## Background

Consumers occasionally crashed when committing offsets because the broker returned a transient `REQUEST_TIMED_OUT` (and `BROKER_NOT_AVAILABLE`) error. These commits would have succeeded on a retry, but the unhandled `KafkaException` propagated all the way up and killed the consumer process.

**See also**

- [Sentry: QLIRO-INTEGRATION-HANDLER-SERVICE-31](https://fyndiq-global.sentry.io/issues/7343530677/?project=4508488261042176)

## Changes

- Retry `AvroConsumer.commit` on transient broker errors (`REQUEST_TIMED_OUT`, `BROKER_NOT_AVAILABLE`)
- Extend `retry_exception` with an optional `condition` callable so callers can filter which exceptions to retry on
- Bump library version

## Validations

- Regression test reproducing the Sentry stacktrace (fails against an unfixed `commit`, passes with the retry decorator applied)
- Unit tests covering the new `condition` parameter and `is_kafka_transient_error` edge cases (empty args, non-`KafkaError` payload)

## Release considerations

Ready to release independently. Low risk — change is scoped to `AvroConsumer.commit`, default `retry_exception` behavior is unchanged, and non-transient errors still fail fast as before.